### PR TITLE
Use PackageReference for SharpDX references

### DIFF
--- a/FamiStudio/FamiStudio.csproj
+++ b/FamiStudio/FamiStudio.csproj
@@ -75,21 +75,11 @@
   </PropertyGroup>
   <PropertyGroup />
   <ItemGroup>
-    <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.Direct2D1, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.Direct2D1.4.2.0\lib\net45\SharpDX.Direct2D1.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.Direct3D11, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.Direct3D11.4.2.0\lib\net45\SharpDX.Direct3D11.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.DXGI, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.DXGI.4.2.0\lib\net45\SharpDX.DXGI.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.XAudio2, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.XAudio2.4.2.0\lib\net45\SharpDX.XAudio2.dll</HintPath>
-    </Reference>
+    <PackageReference Include="SharpDX" Version="4.2.0"/>
+    <PackageReference Include="SharpDX.Direct2D1" Version="4.2.0"/>
+    <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0"/>
+    <PackageReference Include="SharpDX.DXGI" Version="4.2.0"/>
+    <PackageReference Include="SharpDX.XAudio2" Version="4.2.0"/>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
@@ -211,7 +201,6 @@
       <DependentUpon>PropertyDialog.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Nsf\nsf.bin" />
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/FamiStudio/packages.config
+++ b/FamiStudio/packages.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="SharpDX" version="4.2.0" targetFramework="net461" />
-  <package id="SharpDX.Direct2D1" version="4.2.0" targetFramework="net461" />
-  <package id="SharpDX.Direct3D11" version="4.2.0" targetFramework="net461" />
-  <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net461" />
-  <package id="SharpDX.XAudio2" version="4.2.0" targetFramework="net461" />
-</packages>

--- a/README.md
+++ b/README.md
@@ -62,18 +62,9 @@ The solution/projects are in VS2017:
 - You will need C++ support installed if you plan to edit the DLL wrapper around Nes_Snd_Emu.
 - The Setup project is built using the "Microsoft Visual Studio Installer Projects" extension which can be installed from Visual Studio in the "Extensions and Updates" menu.
 
-The C# application is built on top of SharpDX 4.2.0. It should install the required packages automatically, but in case it does not, simply open the Package Manager console and type in the following:
-```
-Install-Package SharpDX -Version 4.2.0
-Install-Package SharpDX.Direct3D11 -Version 4.2.0
-Install-Package SharpDX.Direct2D1 -Version 4.2.0
-Install-Package SharpDX.DXGI -Version 4.2.0
-Install-Package SharpDX.XAudio2 -Version 4.2.0
-```
-If that fails, or if you have general issues with packages, running this in the Package Manager console often fixes issue:
-```
-Update-Package -reinstall
-```
+The C# application is built on top of SharpDX 4.2.0. Visual Studio will install the required packages automatically when building the project.
+To manually fetch the packages, run `msbuild /t:Restore` on the project from the Visual Studio Developer Command Prompt.
+
 ## Issues and Contributing
 Please open issues contact me if you find bugs or have feature suggestion ideas. 
 You can find me:


### PR DESCRIPTION
Wanted to build this locally, which I usually do with `msbuild /t:restore` and `msbuild`, but that failed because of the packages.config setup.
PackageReference is the [preferred](https://docs.microsoft.com/en-us/nuget/consume-packages/overview-and-workflow) way to consume NuGet packages nowadays.
It does mean the project can no longer be compiled with VS2015 or earlier (not sure if that worked before this).