### PR TITLE
Fix note speed not being read from FamiStudio text format and minor documentation errata

### DIFF
--- a/Docs/docs/importexport.md
+++ b/Docs/docs/importexport.md
@@ -198,8 +198,8 @@ Song | Name | Yes | The name of the song.
 | PatternLength | Yes | The number of notes in a pattern.
 | BeatLength | Yes | The number of notes in a beat.
 | NoteLength | Yes | (FamiStudio tempo only) The number of frames in a note. 
-| Tempo | Yes | (FamiTracker tempo only) The FamiTracker tempo.
-| Speed | Yes | (FamiTracker tempo only) The FamiTracker speed.
+| FamiTrackerTempo | Yes | (FamiTracker tempo only) The FamiTracker tempo.
+| FamiTrackerSpeed | Yes | (FamiTracker tempo only) The FamiTracker speed.
 PatternCustomSettings | Time | Yes | Index of the column of pattern that uses these custom settings.
 | Length | Yes | The custom length (in notes or frames) of the pattern.
 | NoteLength | Yes | (FamiStudio tempo only) The number of frames in a note. 

--- a/Docs/docs/importexport.md
+++ b/Docs/docs/importexport.md
@@ -214,6 +214,7 @@ Note | Time | Yes | The frame (or note) number inside the pattern where this not
 | Volume | | The volume of the note, 0 to 15.
 | VibratoSpeed | | The Vibrato speed, 0 to 12.
 | VibratoDepth | | The Vibrato depth, 0 to 15.
+| Speed | | (FamiTracker tempo only) Updates the FamiTracker speed to a new value.
 | FinePitch | | The fine pitch, -128 to 127.
 | SlideTarget | | The slide note target, from C0 to B7.
 | FdsModSpeed | | FDS modulation speed, 0 to 4095.

--- a/FamiStudio/Source/IO/FamistudioTextFile.cs
+++ b/FamiStudio/Source/IO/FamistudioTextFile.cs
@@ -431,6 +431,8 @@ namespace FamiStudio
                                 note.VibratoSpeed = byte.Parse(vibSpeedStr);
                             if (parameters.TryGetValue("VibratoDepth", out var vibDepthStr) && channel.SupportsEffect(Note.EffectVibratoDepth))
                                 note.VibratoDepth = byte.Parse(vibDepthStr);
+                            if (parameters.TryGetValue("Speed", out var speedStr) && channel.SupportsEffect(Note.EffectSpeed))
+                                note.Speed = byte.Parse(speedStr);
                             if (parameters.TryGetValue("FinePitch", out var finePitchStr) && channel.SupportsEffect(Note.EffectFinePitch))
                                 note.FinePitch = sbyte.Parse(finePitchStr);
                             if (parameters.TryGetValue("FdsModSpeed", out var modSpeedStr) && channel.SupportsEffect(Note.EffectFdsModSpeed))


### PR DESCRIPTION
This fixes note speed not being read from the FamiStudio text format.  It also adds the note speed to the format documentation and corrects the names of two attributes which seemed to mismatch.

(fixes #50).