### PR TITLE
fix famitracker tempo pause behaviour

### DIFF
--- a/SoundEngine/famistudio_ca65.s
+++ b/SoundEngine/famistudio_ca65.s
@@ -2457,13 +2457,16 @@ famistudio_update:
 .endif
 
 .if FAMISTUDIO_USE_FAMITRACKER_TEMPO
-    clc  ; Update frame counter that considers speed, tempo, and PAL/NTSC
-    lda famistudio_tempo_acc_lo
-    adc famistudio_tempo_step_lo
-    sta famistudio_tempo_acc_lo
-    lda famistudio_tempo_acc_hi
-    adc famistudio_tempo_step_hi
-    sta famistudio_tempo_acc_hi
+    lda famistudio_song_speed
+    bmi @skip_famitracker_tempo_update ; bit 7 = paused
+        clc  ; Update frame counter that considers speed, tempo, and PAL/NTSC
+        lda famistudio_tempo_acc_lo
+        adc famistudio_tempo_step_lo
+        sta famistudio_tempo_acc_lo
+        lda famistudio_tempo_acc_hi
+        adc famistudio_tempo_step_hi
+        sta famistudio_tempo_acc_hi
+    @skip_famitracker_tempo_update:
 .else
     ; See if we need to run a double frame (playing NTSC song on PAL)
     dec famistudio_tempo_frame_cnt


### PR DESCRIPTION
When using FAMISTUDIO_USE_FAMITRACKER_TEMPO pausing has a problem. The tempo continues to accumulate, and when you unpause the music will play in "fast forward" to catch up.

(This PR fixes the ca65 version only.)