### PR TITLE
Unlimited SFX data length

### DIFF
--- a/FamiStudio/Source/IO/FamitoneSoundEffectFile.cs
+++ b/FamiStudio/Source/IO/FamitoneSoundEffectFile.cs
@@ -181,7 +181,7 @@ namespace FamiStudio
 
                     if (effect.Count > 255)
                     {
-                        Log.LogMessage(LogSeverity.Warning, $"Effect was longer than 256 bytes ({effect.Count}) and was truncated.");
+                        Log.LogMessage(LogSeverity.Warning, $"Effect ({song.Name}) was longer than 256 bytes ({effect.Count}) and was truncated.");
                         effect.RemoveRange(255, effect.Count - 255);
                     }
 

--- a/FamiStudio/Source/IO/FamitoneSoundEffectFile.cs
+++ b/FamiStudio/Source/IO/FamitoneSoundEffectFile.cs
@@ -179,13 +179,8 @@ namespace FamiStudio
                         effect.RemoveRange(lastZeroVolumeIdx, effect.Count - lastZeroVolumeIdx);
                     }
 
-                    if (effect.Count > 255)
-                    {
-                        Log.LogMessage(LogSeverity.Warning, $"Effect ({song.Name}) was longer than 256 bytes ({effect.Count}) and was truncated.");
-                        effect.RemoveRange(255, effect.Count - 255);
-                    }
-
                     effect.Add(0);
+                    Log.LogMessage(LogSeverity.Info, $"Effect ({song.Name}): {effect.Count} bytes.");
 
                     lines.Add($"{ll}sfx_{str}_{Utils.MakeNiceAsmName(song.Name)}:");
 

--- a/FamiStudio/Source/IO/FamitrackerBaseFile.cs
+++ b/FamiStudio/Source/IO/FamitrackerBaseFile.cs
@@ -380,7 +380,7 @@ namespace FamiStudio
 
         private string GetPatternString(Pattern pattern, int n)
         {
-            return $"(Channel={Channel.ChannelNames[pattern.ChannelType]}, Pattern={pattern.Name}, Row={n:X2})";
+            return $"(Song={pattern.Song.Name}, Channel={Channel.ChannelNames[pattern.ChannelType]}, Pattern={pattern.Name}, Row={n:X2})";
         }
 
         private int FindPrevNoteForPortamento(Channel channel, int patternIdx, int noteIdx, Dictionary<Pattern, RowFxData[,]> patternFxData)

--- a/SoundEngine/famistudio_ca65.s
+++ b/SoundEngine/famistudio_ca65.s
@@ -3814,6 +3814,7 @@ famistudio_sfx_play:
 famistudio_sfx_update:
 
     @tmp = famistudio_r0
+    @tmpx = famistudio_r1
     @effect_data_ptr = famistudio_ptr0
 
     lda famistudio_sfx_repeat,x ; Check if repeat counter is not zero
@@ -3857,14 +3858,10 @@ famistudio_sfx_update:
     lda (@effect_data_ptr),y
     iny
     bne :+
-        pha
-        txa
-        pha
+        stx @tmpx
         ldx @tmp
         jsr @inc_sfx
-        pla
-        tax
-        pla
+        ldx @tmpx
     :
     sta famistudio_sfx_buffer-128,x
     ldx @tmp

--- a/SoundEngine/famistudio_ca65.s
+++ b/SoundEngine/famistudio_ca65.s
@@ -3838,6 +3838,9 @@ famistudio_sfx_update:
     bmi @get_data ; If bit 7 is set, it is a register write
     beq @eof
     iny
+    bne :+
+        jsr @inc_sfx
+    :
     sta famistudio_sfx_repeat,x ; If bit 7 is reset, it is number of repeats
     tya
     sta famistudio_sfx_offset,x
@@ -3845,11 +3848,24 @@ famistudio_sfx_update:
 
 @get_data:
     iny
+    bne :+
+        jsr @inc_sfx
+    :
     stx @tmp ; It is a register write
     adc @tmp ; Get offset in the effect output buffer
     tax
     lda (@effect_data_ptr),y
     iny
+    bne :+
+        pha
+        txa
+        pha
+        ldx @tmp
+        jsr @inc_sfx
+        pla
+        tax
+        pla
+    :
     sta famistudio_sfx_buffer-128,x
     ldx @tmp
     jmp @read_byte 
@@ -3910,6 +3926,11 @@ famistudio_sfx_update:
     sta famistudio_output_buf+10
 
 @no_noise:
+    rts
+
+@inc_sfx:
+    inc @effect_data_ptr+1
+    inc famistudio_sfx_ptr_hi,x
     rts
 
 .endif


### PR DESCRIPTION
An alternative to solving #65 , what if this engine just supported effects that were longer than 256 bytes?

The code required to do this is actually only a handful of extra bytes, and performance difference is only an extra 3 cycles per byte of effect read (INY becomes INY BNE). Only once every 256th byte, if the effect is long enough, there's a few more cycles to increment its high address.

(ca65 version only provided in this PR)