### PR TITLE
Update N163 Waveform when the DAW is playing.

### DIFF
--- a/FamiStudio/FamiStudio.csproj
+++ b/FamiStudio/FamiStudio.csproj
@@ -66,6 +66,9 @@
     <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />
     <PackageReference Include="SharpDX.DXGI" Version="4.2.0" />
     <PackageReference Include="SharpDX.XAudio2" Version="4.2.0" />
+    <PackageReference Include="System.Memory">
+      <Version>4.5.4</Version>
+    </PackageReference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/FamiStudio/Source/ChannelStates/ChannelState.cs
+++ b/FamiStudio/Source/ChannelStates/ChannelState.cs
@@ -181,7 +181,9 @@ namespace FamiStudio
             }
             else if (newNote.IsMusical)
             {
-                bool instrumentChanged = note.Instrument != newNote.Instrument || forceInstrumentReload;
+                bool n163WaveformChanged = newNote.Instrument?.ExpansionType == ExpansionType.N163 &&
+                    Utils.ByteArrayCompare<sbyte>(note?.Instrument?.Envelopes[EnvelopeType.N163Waveform].Values, newNote.Instrument.Envelopes[EnvelopeType.N163Waveform].Values);
+                bool instrumentChanged = note.Instrument != newNote.Instrument || forceInstrumentReload || n163WaveformChanged;
                 bool arpeggioChanged   = note.Arpeggio   != newNote.Arpeggio;
 
                 note = newNote;

--- a/FamiStudio/Source/Utils/Utils.cs
+++ b/FamiStudio/Source/Utils/Utils.cs
@@ -328,5 +328,10 @@ namespace FamiStudio
             }
             catch { }
         }
+
+        public static bool ByteArrayCompare<T>(ReadOnlySpan<T> a1, ReadOnlySpan<T> a2) where T : IEquatable<T>
+        {
+            return a1.SequenceEqual(a2);
+        }
     }
 }


### PR DESCRIPTION
This allows a user to realtime update their waveform and get feedback
about the sound of the new note as soon as the next note is played on
the n163 instrument.

Demo: 

https://user-images.githubusercontent.com/952515/118896722-dde1b180-b8d6-11eb-8fdd-240922dc815f.mp4

(If it doesn't load on here, its just a video of the audio loop playing while editing the n163 waveform)


