### PR TITLE
[macOS] Associate FMS file with FamiStudio and make it load when selected in OS

### DIFF
--- a/FamiStudio/Source/UI/GTK/FamiStudioFormGtk.cs
+++ b/FamiStudio/Source/UI/GTK/FamiStudioFormGtk.cs
@@ -146,6 +146,8 @@ namespace FamiStudio
         {
             IntPtr windowHandle = MacUtils.NSWindowFromGdkWindow(GdkWindow.Handle);
             MacUtils.Initialize(windowHandle);
+            MacUtils.FileOpen += Handle_FileOpen;
+            
             DpiScaling.Initialize();
 
             // Hijack GDK main event loop so we can handle some more events.
@@ -153,6 +155,11 @@ namespace FamiStudio
             OldPollFunctionPtr = Marshal.GetDelegateForFunctionPointer<GLibPollFunctionDelegate>(pollFunc);
             NewPollFunctionPtr = GLibPollFunction;
             g_main_context_set_poll_func(IntPtr.Zero, Marshal.GetFunctionPointerForDelegate(NewPollFunctionPtr));
+        }
+        
+        private void Handle_FileOpen(string filename)
+        {
+            famistudio.OpenProject(filename);
         }
 
         private void HandleScrollWheelEvent(IntPtr e)

--- a/FamiStudio/Source/UI/Mac/MacUtils.cs
+++ b/FamiStudio/Source/UI/Mac/MacUtils.cs
@@ -302,7 +302,6 @@ namespace FamiStudio
             eventType.EventClass = EventClassAppleEvent;
             eventType.EventKind = EventOpenDocuments;
 
-            Console.WriteLine("TOTO");
             InstallEventHandler(GetApplicationEventTarget(), HandleOpenDocuments, 1, new CarbonEventTypeSpec[] { eventType }, IntPtr.Zero, out _);
 
             CreateMenu();

--- a/Setup/FamiStudio.app/Contents/Info.plist
+++ b/Setup/FamiStudio.app/Contents/Info.plist
@@ -4,6 +4,29 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>fms</string>
+			</array>
+			<key>CFBundleTypeMIMETypes</key>
+			<array>
+				<string>application/famistudio</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>FamiStudio Project</string>
+			<key>CFBundleTypeIconFile</key>
+			<string>FamiStudio</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSIsAppleDefaultForType</key>
+			<true/>
+		</dict>
+	</array>
 	<key>CFBundleIdentifier</key>
 	<string>com.BleuBleu.FamiStudio</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
Implements #114 and #115

Tested on:
- MacBook Pro 2021 16" M1 Max, macOS 12.2.1
- MacBook Pro 2015 15" , macOS v12.0.1

Screen and voice recording of a test on MBP 2015 👉 https://www.loom.com/share/c63a0c6777a748b2a6b9043d9d23c166