### PR TITLE
Fix "Open Autosave folder" on macOS by quoting the whole path in case it includes a whitespace

### DIFF
--- a/FamiStudio/Source/UI/Mac/PlatformUtils.cs
+++ b/FamiStudio/Source/UI/Mac/PlatformUtils.cs
@@ -235,7 +235,7 @@ namespace FamiStudio
         {
             try
             {
-                Process.Start("open", url);
+                Process.Start("open", $"\"{url}\"");
             }
             catch { }
         }


### PR DESCRIPTION
Fixes #122 by wrapping autosave folder path on macOS with double quotes, making it work even if it contains whitespaces – specifically the one within `Application Support` folder name.