### PR TITLE
Don't ignore short notes in order to avoid rendering empty patterns in Sequencer

### DIFF
--- a/FamiStudio/Source/UI/Common/PatternBitmapCache.cs
+++ b/FamiStudio/Source/UI/Common/PatternBitmapCache.cs
@@ -134,7 +134,7 @@ namespace FamiStudio
                     var time2 = Math.Min(time1 + note.Duration, i < musicalNotes.Count - 1 ? musicalNotes[i + 1].Item1 : ushort.MaxValue);
 
                     var scaledTime1 = Math.Max((int)(time1 * scaleX), lastScaledTime2);
-                    var scaledTime2 = Math.Min((int)Math.Round(time2 * scaleX), patternCacheSizeX);
+                    var scaledTime2 = Math.Min((int)Math.Ceiling(time2 * scaleX), patternCacheSizeX);
 
                     DrawPatternBitmapNote(project, scaledTime1, scaledTime2, note, patternCacheSizeX, clampedPatternCacheSizeY, noteSizeY, minNote, maxNote, scaleY, pattern.ChannelType == ChannelType.Dpcm, data);
 


### PR DESCRIPTION
When calculating length of a bar to visualise a note in Sequencer we used `Math.Round` which can lead to short notes becoming a zero-length bars (no bars at all). In result it was possible to end up with Sequencer which looked like there are empty patterns without notes there (and they were tempting to get rid of them).

In this PR we change rounding from `Math.Round` to `Math.Ceiling` and make all notes have a scaled bar length greater than 0 (OFC except cases where there are multiple notes one after another and we prevent bars from overlapping).

Here is the case of @beetrootpaul's song which looked like DPCM channel has empty patterns:

<img width="1280" alt="before" src="https://user-images.githubusercontent.com/92947323/158280898-8a7dd0eb-ad7a-4efd-b1b4-8e3292d9aabe.png">

And here we can see how `Math.Ceiling` made it visible there actually are some notes in DPCM patterns (difference with previous screenshot is marked red ovals here):

<img width="1283" alt="comparison" src="https://user-images.githubusercontent.com/92947323/158280973-ec04b42e-5eb5-40d5-8789-a49b83f80ea8.png">

---

Fixes #116

