### PR TITLE
8n-bit wave import, 8-bit conversion algorithm fix

### DIFF
--- a/FamiStudio/FamiStudio.Linux.csproj
+++ b/FamiStudio/FamiStudio.Linux.csproj
@@ -202,6 +202,7 @@
     <Compile Include="Source\Utils\Utils.cs" />
     <Compile Include="Source\Utils\WaveUtils.cs" />
     <Compile Include="Source\Video\VideoEncoderFFmpeg.cs" />
+    <Compile Include="GlobalSuppressions.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Nsf\nsf_famistudio_dual.bin" />

--- a/FamiStudio/GlobalSuppressions.cs
+++ b/FamiStudio/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Potential Code Quality Issues", "RECS0022:A catch clause that catches System.Exception and has an empty body", Justification = "<Pending>", Scope = "member", Target = "~M:FamiStudio.WaveFile.Load(System.String,System.Int32@)~System.Int16[]")]
+

--- a/FamiStudio/Source/UI/Common/PianoRoll.cs
+++ b/FamiStudio/Source/UI/Common/PianoRoll.cs
@@ -7800,7 +7800,7 @@ namespace FamiStudio
                 if (IsSelectionValid())
                 {
                     tooltip += "\n{Del} Delete selected samples.";
-                    newNoteTooltip = $"{(selectionMax - selectionMin + 1)} samples selected";
+                    newNoteTooltip = $"{(selectionMax - selectionMin + 1)} sample" + ((selectionMax - selectionMin) == 0 ? "" : "s") + " selected";
                 }
             }
             else if (IsPointInNoteArea(e.X, e.Y))
@@ -7884,7 +7884,7 @@ namespace FamiStudio
                         if (newNoteTooltip.Length > 0)
                             newNoteTooltip += " ";
 
-                        newNoteTooltip += $"{(selectionMax - selectionMin + 1)}{(Song.Project.UsesFamiTrackerTempo ? "notes" : "frames")} selected";
+                        newNoteTooltip += $"{(selectionMax - selectionMin + 1)}{(Song.Project.UsesFamiTrackerTempo ? " note" : " frame")}" + ((selectionMax - selectionMin) == 0 ? "" : "s") + " selected";
                     }
                 }
                 else if (editMode == EditionMode.Envelope || editMode == EditionMode.Arpeggio)
@@ -7896,7 +7896,7 @@ namespace FamiStudio
                         newNoteTooltip = $"{idx:D3} : {value}";
 
                         if (IsSelectionValid())
-                            newNoteTooltip += $" ({selectionMax - selectionMin + 1} frames selected)";
+                            newNoteTooltip += $" ({selectionMax - selectionMin + 1} frame" + ((selectionMax - selectionMin) == 0 ? "" : "s") + " selected)";
                     }
                 }
                 else if (editMode == EditionMode.DPCMMapping)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+(This README.md will be returned back to normal right before merging with the main repo)
+# Basically this is a fork that will implement several features:
+- Converting volumes & duty cycles between 2a03 and expansions
+- Fixing a C0 bug
+- Adding a Demo Songs shortcut
+This fork is not meant for redistribution.
+
 # Welcome to the FamiStudio GitHub page
 This is the GitHub page of FamiStudio, which is intended for people wanting to view/download the source code or report bug fixes.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-(This README.md will be returned back to normal right before merging with the main repo)
-# Basically this is a fork that will implement several features:
-- Converting volumes & duty cycles between 2a03 and expansions
-- Fixing a C0 bug
-- Adding a Demo Songs shortcut
-This fork is not meant for redistribution.
-
 # Welcome to the FamiStudio GitHub page
 This is the GitHub page of FamiStudio, which is intended for people wanting to view/download the source code or report bug fixes.
 


### PR DESCRIPTION
The 24-bit to 16-bit conversion algorithm has been changed to include 32/40..65520/65528-bit data (WaveFile.cs:177)
The log warning has been changed accordingly (WaveFile.cs:196) (More warnings will be changed in a separate PR)
The if-else switching between conversion algorithms has been replaced by... y'know, a switch (WaveFile.cs:159)
The Global Suppressions file is for removing a warning in Monodevelop.
The 8-bit to 16-bit conversion algorithm has been changed to allow the full range of values (WaveFile.cs:164):
`8-bit 16-bit old 16-bit new`
`00 -> 8000 ` ` ` ` ` ` ` ` ` ` 8000`
`40 -> A000 ` ` ` ` ` ` ` ` ` ` A040`
`7F -> FF00 ` ` ` ` ` ` ` ` ` ` FF7F`
`80 -> 0000 ` ` ` ` ` ` ` ` ` ` 0080`
`FF -> 7F00 ` ` ` ` ` ` ` ` ` ` 7FFF`