### PR TITLE
Fix typo in TutorialDialog.cs

### DIFF
--- a/FamiStudio/Source/UI/Desktop/TutorialDialog.cs
+++ b/FamiStudio/Source/UI/Desktop/TutorialDialog.cs
@@ -13,7 +13,7 @@ namespace FamiStudio
             @"(2/11) CONTROLS HAVE CHANGED!!! If you have used FamiStudio in the past, please pay extra attention since the basic mouse controls have changed.",
             @"(3/11) To PAN around the piano roll or the sequencer, simply PRESS and HOLD the MIDDLE MOUSE BUTTON and DRAG around to smoothly move the viewport. Yes, that wheel on your mouse is also a button! Optionally, you can enable SCROLL BARS in the settings.",
             @"(4/11) To ZOOM in and out in the piano roll or the sequencer, simply rotate the MOUSE WHEEL.",
-            @"(5/11) If you are on a TRACKPAD or a LAPTOP, simply enable TRACKPAD CONTROLS in the settings. This will allow you to SWIPE to PAN and PINCH-TO-ZOOM (this gesture is not supported on on Linux).",
+            @"(5/11) If you are on a TRACKPAD or a LAPTOP, simply enable TRACKPAD CONTROLS in the settings. This will allow you to SWIPE to PAN and PINCH-TO-ZOOM (this gesture is not supported on Linux).",
             @"(6/11) To ADD things like patterns and notes, simply CLICK with the LEFT MOUSE BUTTON.",
             @"(7/11) To DELETE things like patterns and notes, simply DOUBLE-CLICK with the LEFT MOUSE BUTTON. Alternatively you can SHIFT-CLICK to delete pattern and notes.",
             @"(8/11) RIGHT-CLICKING on things will usually open a CONTEXT MENU containing more options. Right-click on everything you see to discover what the app can do!",


### PR DESCRIPTION
Fixes small typo in the tutorial: "this gesture is not supported ~~on~~ on Linux"