### PR TITLE
Add P+LeftClick as a shortcut for "Pattern Properties"

### DIFF
--- a/FamiStudio/Source/UI/Common/Sequencer.cs
+++ b/FamiStudio/Source/UI/Common/Sequencer.cs
@@ -1349,6 +1349,23 @@ namespace FamiStudio
             return false;
         }
 
+        private bool HandleMouseDownPatternProperties(MouseEventArgs e)
+        {
+            bool changeProperties = ParentWindow.IsKeyDown(Keys.P);
+            bool inPatternZone = GetPatternForCoord(e.X, e.Y, out var location);
+
+            if (changeProperties && inPatternZone)
+            {
+                var pattern = Song.GetPatternInstance(location);
+                if (pattern != null) {
+                    EditPatternProperties(new Point(e.X, e.Y), pattern, location, false);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private bool HandleMouseDownSeekBar(MouseEventArgs e)
         {
             if (IsMouseInHeader(e) && e.Left)
@@ -1460,6 +1477,7 @@ namespace FamiStudio
             if (HandleMouseDownChannelName(e)) goto Handled;
             if (HandleMouseDownShy(e)) goto Handled;
             if (HandleMouseDownSetLoopPoint(e)) goto Handled;
+            if (HandleMouseDownPatternProperties(e)) goto Handled;
             if (HandleMouseDownSeekBar(e)) goto Handled;
             if (HandleMouseDownHeaderSelection(e)) goto Handled;
             if (HandleMouseDownChannelChange(e)) goto Handled;
@@ -2658,6 +2676,7 @@ namespace FamiStudio
                 if (pattern != null)
                 {
                     tooltipList.Add("<MouseLeft><MouseLeft> or <Shift><MouseLeft> Delete Pattern");
+                    tooltipList.Add("<P><MouseLeft> Pattern Properties...");
                     tooltipList.Add("<MouseRight> More Options...");
                 }
 


### PR DESCRIPTION
When using FamiStudio, I frequently want to rename patterns in bulk:

![image](https://user-images.githubusercontent.com/8108849/228725168-20acb102-a393-4fae-9127-109a8cf88bdd.png)

In FamiStudio 3.x, patterns could be renamed quickly by double-clicking. In 4.0 (I think?), double-clicking was changed to mean "Delete Pattern", and "Pattern Properties" was relegated to the right-click menu. This made mass-renaming significantly more annoying than it used to be.

This PR improves the experience by adding "P+LeftClick" as an alias for "RightClick -> 'Pattern Properties...'".

This wouldn't be the first command to be accessible from both the right-click menu and a shortcut: "Delete Pattern" can currently be invoked in *three* different ways (double-LeftClick, Shift+LeftClick, and the right-click menu).