### PR TITLE
Misspelling fix: "instanciate" -> "instantiate"

### DIFF
--- a/FamiStudio/Source/UI/Common/Sequencer.cs
+++ b/FamiStudio/Source/UI/Common/Sequencer.cs
@@ -103,7 +103,7 @@ namespace FamiStudio
         BitmapAtlasRef[] bmpChannels;
         BitmapAtlasRef bmpForceDisplay;
         BitmapAtlasRef bmpLoopPoint;
-        BitmapAtlasRef bmpInstanciate;
+        BitmapAtlasRef bmpInstantiate;
         BitmapAtlasRef bmpDuplicate;
         BitmapAtlasRef bmpDuplicateMove;
         BitmapAtlasRef bmpShyOn;
@@ -445,7 +445,7 @@ namespace FamiStudio
             bmpChannels = g.GetBitmapAtlasRefs(ChannelType.Icons);
             bmpForceDisplay = g.GetBitmapAtlasRef("GhostSmall");
             bmpLoopPoint = g.GetBitmapAtlasRef("LoopSmallFill");
-            bmpInstanciate = g.GetBitmapAtlasRef("Instance");
+            bmpInstantiate = g.GetBitmapAtlasRef("Instance");
             bmpDuplicate = g.GetBitmapAtlasRef("Duplicate");
             bmpDuplicateMove = g.GetBitmapAtlasRef("DuplicateMove");
 
@@ -747,7 +747,7 @@ namespace FamiStudio
                         if (rowIdxDelta != 0)
                             bmpCopy = (duplicate || instance) ? bmpDuplicate : bmpDuplicateMove;
                         else
-                            bmpCopy = duplicate ? bmpDuplicate : (instance ? bmpInstanciate : null);
+                            bmpCopy = duplicate ? bmpDuplicate : (instance ? bmpInstantiate : null);
 
                         c.PushTranslation(pt.X - channelNameSizeX, y);
                         c.FillAndDrawRectangle(-anchorOffsetLeftX, 0, -anchorOffsetLeftX + patternSizeX, channelSizeY, selectedPatternVisibleColor, Theme.BlackColor);
@@ -1731,7 +1731,7 @@ namespace FamiStudio
                     if (Platform.IsMobile)
                         menu.Add(new ContextMenuOption("MenuExpandSelection", "Expand Selection", () => { EnsureSelectionInclude(location); }));
                     if (selectionMin.ChannelIndex == location.ChannelIndex)
-                        menu.Add(new ContextMenuOption("MenuInstance", "Instanciate Selection Here", () => { CopySelectionToCursor(false); }));
+                        menu.Add(new ContextMenuOption("MenuInstance", "Instantiate Selection Here", () => { CopySelectionToCursor(false); }));
                     menu.Add(new ContextMenuOption("MenuDuplicate", "Duplicate Selection Here", () => { CopySelectionToCursor(true); }));
                 }
 


### PR DESCRIPTION
Just fixing a misspelling.

Side note: I notice there are at least [a couple](https://en.wiktionary.org/wiki/instanciate) [sources online](https://www.wordnik.com/words/instanciate) claiming that "instanciate" could count as an "alternative spelling," but [most](https://www.yourdictionary.com/instanciate) [dictionaries](https://www.dictionary.com/misspelling?term=instanciate) [don't](https://www.merriam-webster.com/dictionary/instanciate) [agree](https://dictionary.cambridge.org/us/spellcheck/english/?q=instanciate) [with](https://www.collinsdictionary.com/spellcheck/english?q=instanciate) [that](https://www.thefreedictionary.com/instanciate). (My browser's spell-check is wavy-red-underlining it, too.) Either way, ["instantiate" is by far the commonly accepted spelling](https://books.google.com/ngrams/graph?content=instantiate%2Cinstanciate).