### PR TITLE
Better line splits for CJK languages

### DIFF
--- a/FamiStudio/Source/UI/Desktop/Controls/Label.cs
+++ b/FamiStudio/Source/UI/Desktop/Controls/Label.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace FamiStudio
 {
@@ -39,18 +41,25 @@ namespace FamiStudio
                 while (true)
                 {
                     var numCharsWeCanFit = Fonts.FontMedium.GetNumCharactersForSize(input, actualWidth);
+                    var minimunCharsPerLine = Math.Max((int)(numCharsWeCanFit * 0.62), numCharsWeCanFit - 20);
                     var n = numCharsWeCanFit;
                     var done = n == input.Length;
                     
                     if (!done)
                     {
-                        while (n > 0 && !char.IsWhiteSpace(input[n]))
+                        while (!char.IsWhiteSpace(input[n]) && input[n] != '\u201C' && char.GetUnicodeCategory(input[n]) != UnicodeCategory.OpenPunctuation)
+                        {
                             n--;
+                            // No whitespace or punctuation found, let's chop in the middle of a word.
+                            if (n <= minimunCharsPerLine)
+                            {
+                                n = numCharsWeCanFit;
+                                if (char.IsPunctuation(input[n]))
+                                    n--;
+                                break;
+                            }
+                        }
                     }
-
-                    // No whitespace found, let's chop in the middle of a word.
-                    if (n == 0)
-                        n = numCharsWeCanFit;
 
                     output += input.Substring(0, n);
                     output += "\n";


### PR DESCRIPTION
Instead of searching for a whitespace until reaches the beginning of a line, it only searches a section from end of the line. This prevents some early line splits.
It will check if the beginning of a line is a punctuation mark if and only if no whitespaces are found. This is to make sure if a force split happens for some East Asian language, it won't leave a comma or a period at the beginning of a new line.