### PR TITLE
Added new strings to pt translation, fixed typos

### DIFF
--- a/FamiStudio/Localization/FamiStudio.por.ini
+++ b/FamiStudio/Localization/FamiStudio.por.ini
@@ -99,20 +99,20 @@ LocalizedNames_8=PWM
 LocalizedNames_9=PWM2
 LocalizedNames_10=PWM3
 
-[EffectType] #TODO!!!
+[EffectType]
 LocalizedNames_0=Volume
-LocalizedNames_1=Vib Speed
-LocalizedNames_2=Vib Depth
-LocalizedNames_3=Pitch
-LocalizedNames_4=Speed
-LocalizedNames_5=FDS Depth
-LocalizedNames_6=FDS Speed
+LocalizedNames_1=Velo. Vib
+LocalizedNames_2=Profund. Vib
+LocalizedNames_3=Tom
+LocalizedNames_4=Velocidade 
+LocalizedNames_5=Profund. FDS
+LocalizedNames_6=Velo. FDS
 LocalizedNames_7=Duty Cycle
-LocalizedNames_8=Note Delay
-LocalizedNames_9=Cut Delay
-LocalizedNames_10=Volume Slide
+LocalizedNames_8=Delay Nota
+LocalizedNames_9=Delay Corte
+LocalizedNames_10=Deslize de Vol.
 LocalizedNames_11=DAC
-LocalizedNames_12=Phase Reset
+LocalizedNames_12=Reset de Fase
 
 [MidiPolyphonyBehavior]
 LocalizedNames_0=Favorecer nota mais recente
@@ -227,7 +227,7 @@ SeperateFilesTooltip=Se ativado, cada canal será exportado para um arquivo indi
 SeperateIntroTooltip=Se ativado, a intro (a parte antes do ponto de repetição), será exportada para um arquivo isndividual. Útil se estiver fazendo jogos.
 StereoTooltip=Se ativado, vai exportar áudio stereo e ativará panning customizado para cada canal na grade abaixo.
 ChannelGridTooltip=Selecione os canais a serem exportados. Se stereo estiver ativado, poderá selecionar o panning para cada canal.
-ChannelGridTooltipVid=Selecione os canais a serem exportados. Se stereo estiver ativado, poderá selecionar o panning para cada canal.\n\nGatilho é o tipo ou algoritmo usado para se alinhar o osciloscópio. Emulação significa que irá tentar usar a frequência da nota atualmente tocando. Isso pode não funcionar muito bem para instrumentos de baixa frequência ou instrumentos que mudam de frequência rapidamente. Velocidade de Pico irá simplesmente olhar a forma da onda e fazer um palpite.
+ChannelGridTooltipVid=Selecione os canais a serem exportados. Se stereo estiver ativado, poderá selecionar o panning para cada canal.\n\nGatilho é o tipo ou algoritmo usado para se alinhar o osciloscópio. Emulação significa que tentará usar a frequência da nota atualmente tocando. Isso pode não funcionar muito bem para instrumentos de baixa frequência ou instrumentos que mudam de frequência rapidamente. Velocidade de Pico irá simplesmente olhar a forma da onda e fazer um palpite.
 ChannelListTooltip=Selecione os canais a serem exportados.
 
 # WAV/MP3 labels
@@ -305,7 +305,7 @@ InstrumentModeLabel=Modo de Instrumento
 InstrumentsLabels=Instrumentos
 
 # FamiStudio Text tooltips
-DeleteUnusedTooltip=Se ativado, irá deletar qualquer dado não utilizado (instrumento, arpeggio, amostra DPCM, etc.) antes da exportação.
+DeleteUnusedTooltip=Se ativado, deletará qualquer dado não utilizado (instrumento, arpeggio, amostra DPCM, etc.) antes da exportação.
 
 # FamiStudio Text labels
 DeleteUnusedDataLabel=Deletar dados não utilizados
@@ -403,14 +403,14 @@ DpcmColorModeStrings_1=Amostra DPCM
 
 # General tooltips
 LanguageTooltip=Linguagem usada através do app.\n\nElas são feitas pelos usuários, então algumas linhas que não foram atualizadas poderam aparecer em inglês.\n\nSe você quer nos ajudar a traduzir o FamiStudio, vem ver a gente no Discord!
-CheckUpdatesTooltip=Quando ativado, o FamiStudio irá checar por atualizações toda vez que iniciar o aplicativo.
+CheckUpdatesTooltip=Quando ativado, o FamiStudio checará por atualizações toda vez que iniciar o aplicativo.
 ShowTutorialTooltip=Quando ativado, o tutorial inicial será mostrado na próxima vez que iniciar o aplicativo.
 ClearUndoRedoTooltip=Quando ativado, a pilha de desfazer/refazer será limpada toda vez que salvar. Disativar isto pode ajudar em manter o uso de memória baixo.
-ReviewAfterPlayTooltip=Quando ativado, FamiStudio voltará para a última posição de reprodução depois depois de parar a música.
-OpenLastTooltip=Quando ativado, FamiStudio abrirá o ultimo projeto no qual estava trabalhando antes de fechar o app.
+ReviewAfterPlayTooltip=Quando ativado, FamiStudio voltará para a última posição de reprodução depois de parar a música.
+OpenLastTooltip=Quando ativado, FamiStudio abrirá o último projeto no qual estava trabalhando antes de fechar o app.
 AutosaveTooltip=Quando ativado, uma cópia do seu projeto será salva a cada 2 minutos aproximadamente. Isso pode prevenir a perda de dados após um crash.
 PatternNamePrefixTooltip=Prefixo a ser adicionado em nomes de padrões gerados automaticamente.
-PatternNameNumDigitsTooltip=Número mínimo de digitos nos nomes de padrões gerados automaticamente.
+PatternNameNumDigitsTooltip=Número mínimo de dígitos nos nomes de padrões gerados automaticamente.
 AutosaveFolderTooltip=Clique para abrir a pasta de auto saves.
 
 # General labels
@@ -429,7 +429,7 @@ OpenAutosaveFolderLabel=Abrir Pasta de Autosave
 ScalingTooltip=Escalamento da janela principal FamiStudio. Deixe em 'Sistema' se quiser que o FamiStudio o detecte automaticamente baseado na configuração do sistema.
 TimeFormatTooltip=Afeta como o tempo é mostrado na barra de ferramentas.
 FollowModeTooltip=Comportamento do rolamento quando ativando o modo seguir na barra de ferramentas.
-FollowingViewsTooltip=Afeta quais telas irão rolar quando ativando o modo seguir na barra de ferramentas.
+FollowingViewsTooltip=Afeta quais telas rolarão quando ativando o modo seguir na barra de ferramentas.
 FollowRangeTooltip=Seleciona a ponta direita da área que à qual a barra de seguimento será restrita no modo seguir 'contínuo'. Isso também se aplica durante a gravação.
 ScrollBarsTooltip=Afeta a visibilidade e o tamanho das barras de rolamento no app.
 ShowFamitrackerStopNotesTooltip=Quando ativado, notas de parar parcialmente transparentes serão mostradas quando uma nota acaba, quando usando o modo de tempo FamiTracker. Isso pode ajudár-lo a alinhar delays de notas com notas de parar.
@@ -437,7 +437,7 @@ IdealSequencerHeightTooltip=O tamanho do sequenciador, em % da altura da janela.
 DpcmColorModeTooltip=Afeta a cor das notas no canal DPCM. Elas podem assumir a cor do instrumento, ou a cor da amostra a qual foram mapeadas.
 AllowSequencerScrollTooltip=Quando ativado e o tamanho ideal do sequenciador não puder ser atingido, o sequenciador permitirá rolamento vertical.
 ShowRegisterViewerTooltip=Quando ativado, a aba 'Registro' será visível no Explorador de Projeto.
-UseOSDialogsTooltip=Quando ativado, o FamiStudio tentará usar o diálogo imbutido do sistema operacional para abrir/salvar arquivos e mostrar mensagens de erro.
+UseOSDialogsTooltip=Quando ativado, o FamiStudio tentará usar o diálogo embutido do sistema operacional para abrir/salvar arquivos e mostrar mensagens de erro.
 
 # UI labels
 ScalingLabel=Escalamento (Requer reiniciar)
@@ -451,13 +451,13 @@ DpcmColorModeLabel=Modo de Cor do Canal DPCM
 AllowSeqVertScrollLabel=Permitir Rolamento Vertical do Sequenciador
 ShowFamitrackerStopLabel=Mostra Notas de Parar FamiTracker
 ShowRegisterViewerLabel=Mostrar Aba de Visualização de Registros
-UseOSDialogsLabel=Usar Dialógos do Sistema Operacional
+UseOSDialogsLabel=Usar Diálogos do Sistema Operacional
 SystemOption=Sistema
 
 # Input tooltips
 TrackpadControlsTooltip=Quando ativado, o esquema de controle será mais amigável para trackpads/laptops. Você poderá deslizar para mover ou beliscar para dar zoom. Note que não é possível beliscar para dar zoom no Linux, e você terá que apertar CTRL ou ALT e rolar para cima/baixo para dar zoom.
-AltLeftForMiddleTooltip=Quando ativado, Alt + clique-esquerdo será interpretado como um clique do botão do meio do mouse. Útil se o seu mouse não tenha um botão do meio.\n\nNote que isso poderá desativar algumas funcionalidades que precisam do Alt, como a abilidade de temporariamente desativar o snapping.
-AltZoomAllowedTooltip=Quando ativado, Alt + clique-direito + mover para cima/baixo darão zoom. Útil se o seu mouse não tenha um botão do meio.\n\nNote que isso poderá desativar algumas funcionalidades que precisam do Alt, como a abilidade de temporariamente desativar o snapping.
+AltLeftForMiddleTooltip=Quando ativado, Alt + clique-esquerdo será interpretado como um clique do botão do meio do mouse. Útil se o seu mouse não tenha um botão do meio.\n\nNote que isso poderá desativar algumas funcionalidades que precisam do Alt, como a habilidade de temporariamente desativar o snapping.
+AltZoomAllowedTooltip=Quando ativado, Alt + clique-direito + mover para cima/baixo darão zoom. Útil se o seu mouse não tenha um botão do meio.\n\nNote que isso poderá desativar algumas funcionalidades que precisam do Alt, como a habilidade de temporariamente desativar o snapping.
 
 # Input labels
 TrackpadControlsLabel=Controles de trackpad
@@ -483,7 +483,7 @@ StopInstrumentAfterLabel=Parar instrumentos após (seg)
 PreventPoppingLabel=Evitar 'pipocamento' nos canais de pulso
 MixN163Label=Mixar canais do Namco 163
 ClampPeriodsLabel=Prender períodos e notas
-MuteDragSoundsLabel=Mutar sons de arraste durante reproduçãp
+MuteDragSoundsLabel=Silenciar sons de arraste durante reprodução
 MetronomeVolumeLabel=Volume do metrônomo
 
 # Mixer tooltips
@@ -501,7 +501,7 @@ ExpansionTrebleLabel=Agudo da Expansão
 ResetLabel=Resetar
 ResetButtonLabel=Resetar expansão para o padrão
 NoteLabel=Nota
-NoteMessageLabel=Nota : Esses não terão nenhum efeito em exportações de NSF, ROM, FDS e sound engine .
+NoteMessageLabel=Nota: Esses não terão nenhum efeito em exportações de NSF, ROM, FDS e sound engine.
 
 # MIDI tooltips
 MidiDeviceTooltip=O dispositivo MIDI device que será usado para a entrada de notas.
@@ -520,7 +520,7 @@ FFmpegSelectExeTitle=Por favor selecione o arquivo executável do FFmpeg
 # Keys labels
 DoubleClickLabel=Dê um clique duplo nas últimas 2 colunas para designar a tecla. Clique-direito para limpar uma tecla.
 ResetDefaultLabel=Resetar pro padrão
-PressKeyOrCancel=Pressione a nova tecla ou ESC para cancel.
+PressKeyOrCancel=Pressione a nova tecla ou ESC para cancelar.
 ActionColumn=Ação
 KeyColumn=Tecla
 KeyAltColumn=Tecla (alt)
@@ -533,29 +533,29 @@ ForceLandscapeTooltip=Quando ativado, a orientação do app será forçada ao mo
 AllowVibrationLabel=Permitir vibração
 ForceLandscapeLabel=Forçar Paisagem
 
-[MobileProjectDialog] #TODO!!!
-UserProjectsSaveTooltip=These are your projects. Select one to overwrite it. The save to a new project file, select the last option and enter a name.
-UserProjectsLoadTooltip=These are your projects. Select one to load it.
-DemoProjectsLoadTooltip=These are demo projects provided with FamiStudio. They are great resources for learning.
-OpenFromStorageTooltip=This will prompt you to open a file from your device's storage. You can open FamiStudio .FMS files, as well as other file formats such as NSF, FamiTracker FTM or TXT files.
-SaveVerb=Save
-OpenVerb=Open
-UserProjectsLabel=User Projects
-NewProjectNameLabel=New Project Name
-NewProjectNameTooltip=Enter the name of the new project.
-DeleteSelectedProjectLabel=Delete Selected Project
-DeleteButton=Delete
-StorageNoteLabel=Note
-StorageNoteText=To export your project to your device's storage or to share them (email, messaging, etc.), please use the 'Share' option from the Export dialog.
-DemoProjectLoadLabel=Demo Projects
-OpenFromStorageLabel=Open project from storage
-OpenFromStorageButton=Open From Storage
-EnterValidFilenameToast=Please enter a valid filename
-OverwriteProjectText=Overwrite project?
-OverwriteProjectTitle=Overwrite
-DeleteProjectText=Delete project?
-DeleteProjectTitle=Delete
-ProjectDeletedToast=Project Deleted!
+[MobileProjectDialog]
+UserProjectsSaveTooltip=Estes são os seus projetos. Selecione um para sobrescrevê-lo. Para salvar em um novo arquivo de projeto, selecione a última opção e digite um nome.
+UserProjectsLoadTooltip=Estes são os seus projetos. Selecione um para carregá-lo.
+DemoProjectsLoadTooltip==Estes são projetos demo que vem com o FamiStudio. Eles são ótimos recursos para se aprender.
+OpenFromStorageTooltip=Isso irá pedi-lo para escolher um arquivo no armazenamento do seu dispositivo. Você pode abrir arquivos .FMS FamiStudio, além de outros formatos como NSF, FTM FamiTracker ou arquivos TXT.
+SaveVerb=Salvar
+OpenVerb=Abrir
+UserProjectsLabel=Projetos do Usuário
+NewProjectNameLabel=Novo Nome de Projeto
+NewProjectNameTooltip=Digite o nome do novo projeto.
+DeleteSelectedProjectLabel=Deletar o Projeto Selecionada
+DeleteButton=Deletar
+StorageNoteLabel=Nota
+StorageNoteText=para exportar o projeto para o armazenamento do seu dispositivo ou para compartilhár-los (email, mensagens, etc.), por favor use a opção 'Compartilhar' no diálogo de exportação.
+DemoProjectLoadLabel=Projetos Demo
+OpenFromStorageLabel=Abrir projeto do armazenamento
+OpenFromStorageButton=Abrir do Armazenamento
+EnterValidFilenameToast=Por favor digite um nome válido
+OverwriteProjectText=Sobrescrever projeto?
+OverwriteProjectTitle=Sobrescrever
+DeleteProjectText=Deletar projeto?
+DeleteProjectTitle=Deletar
+ProjectDeletedToast=Projeto Deletado!
 
 [TransformDialog]
 
@@ -569,8 +569,8 @@ Verb=Aplicar
 # Song tooltips
 MergePatternsTooltip=Padrões idênticos e no mesmo canal serão fundidos e trocados por um único padrão.
 DeleteEmptyPatternsTooltip=Padrões sem notas musicais ou efeitos serão deletados.
-AdjustMaximumNoteLengthsTooltip=Notas que são longas, mas que são interrompidas por uma outa nota no mesmo canal terão seu tamanhos reduzidos para equivalerem à sua duração visual.
-SongsTooltip=Selecione as músicas a serem limpadas.
+AdjustMaximumNoteLengthsTooltip=Notas que são longas, mas que são interrompidas por uma outa nota no mesmo canal terão seus tamanhos reduzidos para equivalerem à sua duração visual.
+SongsTooltip=Selecione as músicas para limpar.
   
 # Song labels
 MergePatternsLabel=Fundir padrões idênticos
@@ -582,8 +582,8 @@ SongsLabel=Músicas a processar
 DeleteUnusedInstrumentsTooltip=Deleta instrumentos que não são usados em lugar algum no projeto.
 MergeIdenticalInstrumentsTooltip=Se dois ou mais instrumentos são idênticos, os redundantes serão deletados e trocados por um único instrumento.
 UnassignUnusedSamplesTooltip=Remove amostras dos 'Instrumento DPCM' que não são usadas na música. Não deleta as amostras em si do projeto.
-DeleteUnassignedSamplesTooltip=Deleta amostras DPCM que não foram designadas à uma nota no 'Instrumento DPCM'.
-PermanentlyApplyProcessingTooltip=Para cada amostra DPCM que usa processamento (ajuste de volume, etc.), os aplicará permanentemente aos dados DMC e o fará os dados fonte. Apenas faça isso você tem certeza que terminou de ajustar-los. Para amostras que usam arquivos WAV como fonte, isso pode tornar seu projeto muito menor.
+DeleteUnassignedSamplesTooltip=Deleta amostras DPCM que não foram designadas a uma nota no 'Instrumento DPCM'.
+PermanentlyApplyProcessingTooltip=Para cada amostra DPCM que usa processamento (ajuste de volume, etc.), os aplicará permanentemente aos dados DMC e o fará os dados-fonte. Apenas faça isso você tem certeza que terminou de ajustá-los. Para amostras que usam arquivos WAV como fonte, isso pode tornar seu projeto muito menor.
 DiscardN163FdsResampleWavTooltip=Descarta qualquer dado fonte para instrumentos FDS/N163 que são reamostrados de um arquivo WAV. Você pode fazer isto para diminuir o tamanho do seu projeto quando tiver acabado de ajustar os parâmetros de reamostramento.
 DeleteUnusedArpeggiosTooltip=Deleta qualquer arpeggio que não é usado em nenhum lufar no projeto.
 
@@ -593,7 +593,7 @@ MergeIdenticalInstrumentsLabel=Fundir instrumentos idênticos
 UnassignUnusedSamplesLabel=Remover teclas não utilizadas do instrumento DPCM
 DeleteUnassignedSamplesLabel=Deletar amostras não designadas
 PermanentlyApplyProcessingLabel=Aplicar permanentemente o processamento às amostras DPCM
-DiscardN163FdsResampleWavLabel=Descart dados WAV reamostrados para FDS/N163
+DiscardN163FdsResampleWavLabel=Descartar dados WAV reamostrados para FDS/N163
 DeleteUnusedArpeggiosLabel=Delete arpeggios não utilizados
 
 [TempoProperties]
@@ -727,14 +727,14 @@ DeletePatternLabel=Deletar Padrão
 PasteTitle=Colar
 PasteMissingInstrumentsMessage=Você esta colando notas que se referem a instrumentos desconhecidos. Você quer criar o instrumento faltante?
 PasteMissingArpeggiosMessage=Você esta colando notas que se referem a arpeggios desconhecidos. Você quer criar o arpeggio faltante?
-PasteMissingSamplesMessage=Você esta colando notas que se referem a amostras desconhecidss. Você quer criar a amostra faltante?
+PasteMissingSamplesMessage=Você esta colando notas que se referem a amostras desconhecidas. Você quer criar a amostra faltante?
 
 # Paste special dialog
 PasteSpecialTitle=Colar Especial
 InsertLabel=Inserir
 InsertTooltip=Quando ativado, moverá os padrões existentes para a direita para dar espaço para os padrões colados.
 ExtendSongLabel=Extender Música
-ExtendSongTooltip=Quando ativado, extenderá a música para dar espaço para os padrões colados.
+ExtendSongTooltip=Quando ativado, estenderá a música para dar espaço para os padrões colados.
 RepeatLabel=Repetir
 RepeatTooltip=Número de vezes a se colar os padrões.
 
@@ -804,14 +804,14 @@ PropertiesInstrumentTooltip=Propriedades do instrumento
 PropertiesProjectTooltip=Propriedades do projeto
 PropertiesSongTooltip=Propriedades da música/tempo
 ReloadSourceDataTooltip=Recarregar dados fonte (se disponíveis)\nApenas possível caso os dados foram carregados de um arquivo DMC/WAV
-ReorderSongsTooltip=Re-ordenar música
+ReorderSongsTooltip=Reordenar música
 ReplaceArpeggioTooltip=Substituir arpeggio
 SelectArpeggioTooltip=Selecionar arpeggio
 SelectInstrumentTooltip=Selecionar instrumento
 ToggleValueTooltip=Alternar valor
 
 # Messages
-CopyArpeggioMessage=Você tem ceteza que quer copidar os valores de arpeggio de '{0}' para '{1}'?
+CopyArpeggioMessage=Você tem certeza que quer copiar os valores de arpeggio de '{0}' para '{1}'?
 CopyArpeggioTitle=Copiar Arpeggio
 ErrorTitle=Erro
 MaxWavFileWarning=O tamanho máximo suportado para um arquivo WAV é de {0} segundos. Cortando.
@@ -835,7 +835,7 @@ CantFindSourceFileError=Não foi possível encontrar o arquivo-fonte '{0}'!
 
 # Import songs dialog
 ImportSongsTitle=Importar Músicas
-ImportSongsLabel=Select songs to import
+ImportSongsLabel=Selecione músicas para importar
 SelectAllLabel=Selecionar Todas
 SelectNoneLabel=Selecionar Nenhuma
 
@@ -848,7 +848,7 @@ ImportSamplesTitle=Importar amostras DPCM
 ImportSamplesLabel=Selecione as amostras a serem importadas
 
 # Auto-assign banks dialog
-AutoAssignBanksTitle=Auto-Designar Bancos
+AutoAssignBanksTitle=Auto-designar Bancos
 TargetBankSizeLabel=Selecionar o tamanho alvo dos bancos
 
 # Project properties dialog
@@ -860,15 +860,15 @@ ProjectTempoModeLabel=Modo de Tempo
 ProjectMachineLabel=Máquina de Autoria
 ProjectN163ChannelsLabel=Canais N163
 ProjectExpansionLabel=Expansão de Áudio
-ProjectChangeTempoModeTitle=Mudarmodo de tempo
+ProjectChangeTempoModeTitle=Mudar modo de tempo
 ProjectConvertToFamiTrackerMessage=Conversão do tempo FamiTracker para o tempo FamiStudio ainda é extremamente simples. Ela vai ignorar mudanças de velocidade e assumir um tempo de 150. É bem provável de que as músicas precisaram de correções manuais após serem convertidas.
-ProjectConvertToFamiStudioMessage=Converter do tempo FamiStudio para o tempo FamiTracker irá simplesemente tornar a velocidade 1 e o tempo 150. Isso não irá juntar notas ou fazer algo sofisticado.
+ProjectConvertToFamiStudioMessage=Converter do tempo FamiStudio para o tempo FamiTracker irá simplesemente tornar a velocidade 1 e o tempo 150. Isso não juntará notas ou fazer algo sofisticado.
 ProjectExpansionRemovedMessage=Todos os canais e instrumentos relacionados à(s) expansão(ões) removida(s) foram deletados.
 ProjectChangedN163ChannelMessage=Mudar o número de canais N163 pode ter mudado a posição das ondas dos seus instrumentos N163.
 ProjectMultipleExpansionsROMWarning=Usar múltiplas expansões irá preveni-lo de exportar pro FamiTracker ou como uma ROM de NES.
-ProjectExpansionAudioTooltip=Expansão(ões) de chip de aúdio para usar. Isto adicionará canais de áudio extras e desativará qualquer suporte PAL.
+ProjectExpansionAudioTooltip=Expansão(ões) de chip de áudio para usar. Isto adicionará canais de áudio extras e desativará qualquer suporte PAL.
 ProjectExpansionNumChannelsTooltip=Áudio Namco 163 suporta entre 1 e 8 canais. Na medida que você adiciona canais, a qualidade de áudio deteriora. Apenas disponível quando a expansão 'Namco 163' esta ativada.
-ProjectTempoModeTooltip=Tempo FamiStudio lhe dá controle preciso sobre cada quadro, tem bom suporte para conversão PAL/NTSC e é a maneira recomendada de se usar o FamiStudio. Tempo FamiTracker age como o FamiTracker com configurações de velocidade/tempo. Use apenas se você tiver necessidades de compatibilidade bem específicas, já que o suporte é limitado e não resultatará na melhot experiência FamiStudio.
+ProjectTempoModeTooltip=Tempo FamiStudio lhe dá controle preciso sobre cada quadro, tem bom suporte para conversão PAL/NTSC e é a maneira recomendada de se usar o FamiStudio. Tempo FamiTracker age como o FamiTracker com configurações de velocidade/tempo. Use apenas se você tiver necessidades de compatibilidade bem específicas, já que o suporte é limitado e não resultará na melhor experiência FamiStudio.
 ProjectAuthoringMachineTooltip=Para uso com o tempo FamiStudio. Define a máquina na qual a música é editada. Reprodução para o outro espaço será aproximada, mas ainda boa.
 
 # Song properties dialog
@@ -975,9 +975,9 @@ EditingInstrumentEnvelopeLabel=Editando Instrumento {0} ({1})
 EditingInstrumentDPCMLabel=Editando Instrumento {0} (Amostras DPCM)
 DPCMSourceDataLabel=Dados Fonte ({0}) : {1} Hz, {2} Bytes, {3} ms
 DPCMProcessedDataLabel=Dados Processados (DMC) : {0}, {1} Bytes, {2} ms
-DPCMPreviewPlaybackLabel=Previsualizar Reprodução : {0}, {1} ms
+DPCMPreviewPlaybackLabel=Pré-visualizar Reprodução : {0}, {1} ms
 DPCMInstrumentUsageLabel={0} / {1} bytes usados por este instrumento
-InstrumentNotSelectedLabel=Aviso : O instrument não está atualmente selecionado. O instrumento selecionado '{0}' será ouvido quando tocar o piano.
+InstrumentNotSelectedLabel=Aviso : O instrumento não está atualmente selecionado. O instrumento selecionado '{0}' será ouvido quando tocar o piano.
 ArpeggioOverriddenLabel=Aviso : Envelope do arpeggio atualmente anulado pelo arpeggio selecionado '{0}'
 ArpeggioNotSelectedLabel=Warning : Arpeggio não está atualmente selecionado.
 SelectedArpeggioWillBeHeardLabel=O arpeggio selecionado '{0}' será ouvido quando tocar o piano.
@@ -993,7 +993,7 @@ LoopingLabel=Loopeando
 DMCInitialValueLabel=Valor Inicial DMC
 TransposeSampleMessage=Você quer transpôr todas as notas usando esta amostra?
 TransposeSampleTitle=Remapear Amostra DPCM
-NoDPCMSampleMessage=Antes de designar uma amostra à uma tecla, carregue pelo menos uma amostra na seção 'Amostras DPCM' do explorador de projeto
+NoDPCMSampleMessage=Antes de designar uma amostra a uma tecla, carregue pelo menos uma amostra na seção 'Amostras DPCM' do explorador de projeto
 NoDPCMSampleTitle=Nenhuma amostra DPCM encontrada
 
 # DPCM mapping assignment
@@ -1008,12 +1008,12 @@ DMCInitialValueDiv2Label=Valor Inicial DMC (÷2)
 
 # Paste messages
 PasteTitle=Colar
-PasteMissingInstrumentsMessage=Você esta colando notas que se referem a instrumentos desconhecidos. Você quer criar o instrumento faltante?
-PasteMissingArpeggiosMessage=Você esta colando notas que se referem a arpeggios desconhecidos. Você quer criar o arpeggio faltante?
-PasteMissingSamplesMessage=Você esta colando notas que se referem a amostras desconhecidss. Você quer criar a amostra faltante?
+PasteMissingInstrumentsMessage=Você está colando notas que se referem a instrumentos desconhecidos. Você quer criar o instrumento faltante?
+PasteMissingArpeggiosMessage=Você está colando notas que se referem a arpeggios desconhecidos. Você quer criar o arpeggio faltante?
+PasteMissingSamplesMessage=Você está colando notas que se referem a amostras desconhecidas. Você quer criar a amostra faltante?
 
 # Context menus
-DeleteSelectedNotesContext=Deletar Notas Selectionadas
+DeleteSelectedNotesContext=Deletar Notas Selecionadas
 DeleteNoteContext=Deletar Nota
 ToggleNoteAttackContext=Ativar/Desativar Ataque da Nota
 ToggleSelectedNoteAttackContext=Ativar/Desativar Ataque da Seleção
@@ -1167,7 +1167,7 @@ NsfImportTitle=Importação NSF
 SongLabel=Musica
 DurationLabel=Duração (s)
 PatternLength=Tamanho do Padrão
-StartFrameLabel=Quadro de Inicio
+StartFrameLabel=Quadro de Início
 RemoveIntroSilenceLabel=Remover silêncio da introdução
 ReverseDPCMBitsLabel=Inverter bits DPCM
 PreserveDPCMPaddingByte=Preservar padding byte de DPCM
@@ -1227,7 +1227,7 @@ SustainedLabel=Sustain
 HalfSineLabel=Meio Seno
 KeyScalingRateLabel=Key Scaling Rate
 KeyScalingLevelLabel=Key Scaling Level
-FreqMultiplierLabel=FreqMultiplier
+FreqMultiplierLabel=Multipl. de Freq.
 AttackLabel=Attack
 DecayLabel=Decay
 SustainLabel=Sustain
@@ -1249,7 +1249,7 @@ FrequencyRatioLabel=Frequency Ratio
 VolumeLabel=Volume
 KeyScaleLabel=Key Scale
 AttackRateLabel=Attack Rate
-AmplitudeModulationLabel=Amplitude Modulation
+AmplitudeModulationLabel=Modulação de Ampl.
 DecayRateLabel=Decay Rate
 SustainRateLabel=Sustain Rate
 SustainLevelLabel=Sustain Level
@@ -1258,7 +1258,7 @@ SsgEnvEnLabel=SSG-Envelope EN
 SsgEnvLabel=SSG-Envelope
 
 # Common tooltips
-PitchEnvelopeTooltip=Envelopes absolutos mostram o tom real para um dado tempo\nEnvelopes relativos adicionam o tom à uma soma corrente (estilo FamiTracker)
+PitchEnvelopeTooltip=Envelopes absolutos mostram o tom real para um dado tempo\nEnvelopes relativos adicionam o tom a uma soma corrente (estilo FamiTracker)
 
 [DPCMSampleParamProvider]
 
@@ -1275,27 +1275,27 @@ ReverseBitsLabel=Inverter Bits
 BankNumberLabel=Número de Banco
 
 # tooltips
-PreviewRateTooltip=Taxa a ser usada quando previsualizando os\ndados DMC processados com o botão de reprodução acima
-SampleRateTooltip=Taxa na qual se deve reamostrar os dados fonte em
+PreviewRateTooltip=Taxa a ser usada quando pré-visualizando os\ndados DMC processados com o botão de reprodução acima
+SampleRateTooltip=Taxa na qual se deve reamostrar os dados-fonte em
 PaddingModeTooltip=Método de padding para os dados DMC processados
-DmcInitialValueDiv2Tooltip=Valor inicial do contador DMC antes de qualquer ajuste de volume.\nIsto é na verdade metade do valor usado no hardware.
+DmcInitialValueDiv2Tooltip=Valor inicial do contador DMC antes de qualquer ajuste de volume.\nIsto é, na verdade, metade do valor usado no hardware.
 VolumeAdjustTooltip=Ajuste de volume (%)
-FineTuningTooltip=Ajuste de tom muito fino para ajudár-lo a afinar notas 
-ProcessPalTooltip=Usar taxas de amostragem PAL para todo o processamento\nPara dados fonte DMC, assume taxa de amostragem PAL
+FineTuningTooltip=Ajuste de tom muito fino para ajudá-lo a afinar notas 
+ProcessPalTooltip=Usar taxas de amostragem PAL para todo o processamento\nPara dados-fonte DMC, assume taxa de amostragem PAL
 TrimZeroVolumeTooltip=Remove partes dos dados fonte que são considerados baixas demais para serem audíveis
-ReverseBitsTooltip=Para dados fonte DMC apenas, inverte os bits para corrigir erros em alguns jogos de NES
+ReverseBitsTooltip=Para dados-fonte DMC apenas, inverte os bits para corrigir erros em alguns jogos de NES
 BankNumberTooltip=Banco no qual a amostra será colocada\nAfeta apenas exportações de sound engine
 
 [TutorialDialog]
 # Desktop Tutorial
-TutorialMessages_0=(1/10) Bem-vindo(a) ao FamiStudio! Vamos tomar alguns segundo para revisar os controles básicos para certificar que você use esse aplicativo da melhor maneira possível.
+TutorialMessages_0=(1/10) Bem-vindo(a) ao FamiStudio! Vamos tomar alguns segundos para revisar os controles básicos para que você possa usar este aplicativo da melhor maneira possível.
 TutorialMessages_1=(2/10) Para se MOVER pelo piano roll ou sequenciador, simplesmente APERTE e SEGURE o BOTÃO DO MEIO DO MOUSE e ARRASTE para se mover suavemente pelo tela. Sim, aquela rodinha no seu mouse também é um botão! Opcionalmente, você também pode ativar BARRAS DE ROLAMENTO nas configurações.
 TutorialMessages_2=(3/10) Para dar ZOOM no piano roll ou sequenciador, simplesmente rode a RODA DO MOUSE.
 TutorialMessages_3=(4/10) Se você usa um TRACKPAD ou LAPTOP, simplesmente ative os CONTROLES DE TRACKPAD nas configurações. Isso lhe permitirá ARRASTAR para MOVER e BELISCAR para dar ZOOM (esse gesto não é suportado no Linux).
-TutorialMessages_4=(5/10) Para ADICIONAR coisas como padrões e notas, simplesemente CLIQUE com o BOTÃO ESQUERDO DO MOUSE.
+TutorialMessages_4=(5/10) Para ADICIONAR coisas como padrões e notas, simplesmente CLIQUE com o BOTÃO ESQUERDO DO MOUSE.
 TutorialMessages_5=(6/10) Para DELETAR coisas como padrões e notas, simplesmente dê um CLIQUE-DUPLO com o BOTÃO ESQUERDO DO MOUSE. Alternativamente você pode dar um SHIFT-CLIQUE para deletar padrões e notas.
 TutorialMessages_6=(7/10) Dar um CLIQUE DIREITO em algo usualmente abre um MENU CONTEXTUAL contendo mais opções. Dê um CLIQUE DIREITO oem tudo que vê para descobrir o que o aplicativo pode fazer!
-TutorialMessages_7=(8/10) SNAPPING está ATIVADO por padrão e é expressado em BATIDAS. Com as configurações padrão, irá alinhar às notas de 1/4. Você pode mudar a precisão do snapping ou desativá-lo completamente para criar notas de tamanhos diferentes! Você também pode desativar o snapping temporariamente apertando a tecla ALT ao mover ou redimensionar notas.
+TutorialMessages_7=(8/10) SNAPPING está ATIVADO por padrão, e é expressado em BATIDAS. Com as configurações padrão, alinhará às notas de 1/4. Você pode mudar a precisão do snapping ou desativá-lo completamente para criar notas de tamanhos diferentes! Você também pode desativar o snapping temporariamente apertando a tecla ALT ao mover ou redimensionar notas.
 TutorialMessages_8=(9/10) Preste atenção nas DICAS! Elas mudam constantemente ao mover o mouse e te ensinarão como usar o app! Para ver a DOCUMENTAÇÃO completa e o VÍDEO TUTORIAL de mais de 1 hora, por favor clique no grande PONTO DE INTERROGAÇÃO.
 TutorialMessages_9=(10/10) Junte-se a nós no DISCORD para conhecer outros usuários FamiStudio e compartilhar suas músicas com eles! Link na documentação (ponto de interrogação na barra de ferramentas)
 DoNotShowAgainLabel=Não mostrar novamente
@@ -1307,7 +1307,7 @@ TutorialMessages_0=(1/12) Bem-vindo(a) ao FamiStudio! Vamos tomar alguns segundo
 TutorialMessages_1=(2/12) Um TOQUE RÁPIDO geralmente ADICIONA coisas, como padrões ou notas.
 TutorialMessages_2=(3/12) Um TOQUE RÁPIDO também alternará o DESTAQUE ao redor de certos objetos. Você pode mover e/ou interagir com objetos com um DESTAQUE BRANCO de uma maneira especial.
 TutorialMessages_3=(4/12) Um DESLIZE geralmente vai MOVER sua visão. Um DESLIZE no cabeçalho selecionará coisas.
-TutorialMessages_4=(5/12) Um DESLIZE começandoem um objeto DESTACADO pode permitir que você o mova, ou  mude algumas de suas propriedades.
+TutorialMessages_4=(5/12) Um DESLIZE começando em um objeto DESTACADO pode permitir que você o mova, ou mude algumas de suas propriedades.
 TutorialMessages_5=(6/12) Você pode BELISCAR para dar zoom no Piano Roll e no Sequenciador.
 TutorialMessages_6=(7/12) Um APERTO LONGO em alguns objetos revelará um MENU CONTEXTUAL contendo opções de edição mais avançadas. Tente isso em tudo e veja o que acontece!
 TutorialMessages_7=(8/12) Você pode acessar as três telas principais (Sequenciador, Piano Roll e Explorador de Projetos) pela BARRA DE ACESSO RÁPIDO localizada na direita (ou em baixo no modo retrato).


### PR DESCRIPTION
Besides the new strings, also fixed a plethora of typos and spelling mistakes

The biggest change spelling wise was probably the changing of 'irá x' to 'x-rá' (i.e 'irá tentar' becomes 'tentará', both meaning 'will try'), so the verbs flow better now.

Also shortened some long phrases so that they hopefully fit better.
