### PR TITLE
Add Rainbow-net mapper configuration for VRC6 audio

### DIFF
--- a/SoundEngine/UnitTests/run_tests.bat
+++ b/SoundEngine/UnitTests/run_tests.bat
@@ -61,7 +61,7 @@ if "%rnd%"=="1" (
 	)
 )
 
-set /a rnd=%random% %%7
+set /a rnd=%random% %%8
 if "%rnd%"=="0" (
 	echo FAMISTUDIO_EXP_VRC6=1 >> test_defs.inc
 ) else (
@@ -104,6 +104,10 @@ if "%rnd%"=="0" (
 							echo FAMISTUDIO_EXP_EPSM_RHYTHM_CHN5_ENABLE=!rnd! >> test_defs.inc
 							set /a rnd=%random% %%2
 							echo FAMISTUDIO_EXP_EPSM_RHYTHM_CHN6_ENABLE=!rnd! >> test_defs.inc
+						) else (
+							if "%rnd%"=="7" (
+								echo FAMISTUDIO_EXP_RAINBOW=1 >> test_defs.inc
+							)
 						)
 					)
 				)

--- a/SoundEngine/famistudio_asm6.asm
+++ b/SoundEngine/famistudio_asm6.asm
@@ -97,6 +97,9 @@ FAMISTUDIO_ASM6_CODE_BASE = $8000
 ; Konami VRC6 (2 extra square + saw)
 ; FAMISTUDIO_EXP_VRC6          = 1 
 
+; Rainbow-Net (homebrew clone of VRC6)
+; FAMISTUDIO_EXP_RAINBOW       = 1
+
 ; Konami VRC7 (6 FM channels)
 ; FAMISTUDIO_EXP_VRC7          = 1 
 
@@ -251,6 +254,14 @@ FAMISTUDIO_USE_ARPEGGIO          = 1
 ;======================================================================================================================
 ; INTERNAL DEFINES (Do not touch)
 ;======================================================================================================================
+
+.ifndef FAMISTUDIO_EXP_RAINBOW
+    FAMISTUDIO_EXP_RAINBOW = 0
+.endif
+
+.if FAMISTUDIO_EXP_RAINBOW
+    FAMISTUDIO_EXP_VRC6 = 1
+.endif
 
 .ifndef FAMISTUDIO_EXP_VRC6
     FAMISTUDIO_EXP_VRC6 = 0
@@ -1051,6 +1062,17 @@ FAMISTUDIO_APU_DMC_LEN    = $4013
 FAMISTUDIO_APU_SND_CHN    = $4015
 FAMISTUDIO_APU_FRAME_CNT  = $4017
 
+.if FAMISTUDIO_EXP_RAINBOW
+FAMISTUDIO_VRC6_PL1_VOL   = $41a0
+FAMISTUDIO_VRC6_PL1_LO    = $41a1
+FAMISTUDIO_VRC6_PL1_HI    = $41a2
+FAMISTUDIO_VRC6_PL2_VOL   = $41a3
+FAMISTUDIO_VRC6_PL2_LO    = $41a4
+FAMISTUDIO_VRC6_PL2_HI    = $41a5
+FAMISTUDIO_VRC6_SAW_VOL   = $41a6
+FAMISTUDIO_VRC6_SAW_LO    = $41a7
+FAMISTUDIO_VRC6_SAW_HI    = $41a8
+.else
 FAMISTUDIO_VRC6_PL1_VOL   = $9000
 FAMISTUDIO_VRC6_PL1_LO    = $9001
 FAMISTUDIO_VRC6_PL1_HI    = $9002
@@ -1060,6 +1082,7 @@ FAMISTUDIO_VRC6_PL2_HI    = $a002
 FAMISTUDIO_VRC6_SAW_VOL   = $b000
 FAMISTUDIO_VRC6_SAW_LO    = $b001
 FAMISTUDIO_VRC6_SAW_HI    = $b002
+.endif
 
 FAMISTUDIO_VRC7_SILENCE   = $e000
 FAMISTUDIO_VRC7_REG_SEL   = $9010

--- a/SoundEngine/famistudio_ca65.s
+++ b/SoundEngine/famistudio_ca65.s
@@ -96,7 +96,10 @@
 ;======================================================================================================================
 
 ; Konami VRC6 (2 extra square + saw)
-; FAMISTUDIO_EXP_VRC6          = 1 
+; FAMISTUDIO_EXP_VRC6          = 1
+
+; Rainbow-Net (homebrew clone of VRC6)
+; FAMISTUDIO_EXP_RAINBOW       = 1
 
 ; Konami VRC7 (6 FM channels)
 ; FAMISTUDIO_EXP_VRC7          = 1 
@@ -252,6 +255,14 @@ FAMISTUDIO_USE_ARPEGGIO          = 1
 ;======================================================================================================================
 ; INTERNAL DEFINES (Do not touch)
 ;======================================================================================================================
+
+.ifndef FAMISTUDIO_EXP_RAINBOW
+    FAMISTUDIO_EXP_RAINBOW = 0
+.endif
+
+.if FAMISTUDIO_EXP_RAINBOW
+    FAMISTUDIO_EXP_VRC6 = 1
+.endif
 
 .ifndef FAMISTUDIO_EXP_VRC6
     FAMISTUDIO_EXP_VRC6 = 0
@@ -1069,6 +1080,17 @@ FAMISTUDIO_APU_DMC_LEN    = $4013
 FAMISTUDIO_APU_SND_CHN    = $4015
 FAMISTUDIO_APU_FRAME_CNT  = $4017
 
+.if FAMISTUDIO_EXP_RAINBOW
+FAMISTUDIO_VRC6_PL1_VOL   = $41a0
+FAMISTUDIO_VRC6_PL1_LO    = $41a1
+FAMISTUDIO_VRC6_PL1_HI    = $41a2
+FAMISTUDIO_VRC6_PL2_VOL   = $41a3
+FAMISTUDIO_VRC6_PL2_LO    = $41a4
+FAMISTUDIO_VRC6_PL2_HI    = $41a5
+FAMISTUDIO_VRC6_SAW_VOL   = $41a6
+FAMISTUDIO_VRC6_SAW_LO    = $41a7
+FAMISTUDIO_VRC6_SAW_HI    = $41a8
+.else
 FAMISTUDIO_VRC6_PL1_VOL   = $9000
 FAMISTUDIO_VRC6_PL1_LO    = $9001
 FAMISTUDIO_VRC6_PL1_HI    = $9002
@@ -1078,6 +1100,7 @@ FAMISTUDIO_VRC6_PL2_HI    = $a002
 FAMISTUDIO_VRC6_SAW_VOL   = $b000
 FAMISTUDIO_VRC6_SAW_LO    = $b001
 FAMISTUDIO_VRC6_SAW_HI    = $b002
+.endif
 
 FAMISTUDIO_VRC7_SILENCE   = $e000
 FAMISTUDIO_VRC7_REG_SEL   = $9010

--- a/SoundEngine/famistudio_multi_ca65.s
+++ b/SoundEngine/famistudio_multi_ca65.s
@@ -69,7 +69,7 @@
     FAMISTUDIO_CFG_EXTERNAL = 0
 .endif
 
-; [MULTI] BEGIN : Always enable all expansions (except EPSM), all the following code will assume that they are. 
+; [MULTI] BEGIN : Always enable all expansions (except EPSM and Rainbow), all the following code will assume that they are. 
 ; We dont care about memory/performance here.
 FAMISTUDIO_EXP_VRC6 = 1 
 FAMISTUDIO_EXP_VRC7 = 1 
@@ -266,6 +266,12 @@ FAMISTUDIO_USE_ARPEGGIO          = 1
 .ifndef FAMISTUDIO_EXP_VRC6
     FAMISTUDIO_EXP_VRC6 = 0
 .endif
+
+; [MULTI] BEGIN - Don't allow rainbow mapper since its just a VRC6 clone
+.if FAMISTUDIO_EXP_RAINBOW
+.error "Rainbow mapper is not enabled for multi expansion! Just use VRC6"
+.endif
+; [MULTI] END
 
 .ifndef FAMISTUDIO_EXP_VRC7
     FAMISTUDIO_EXP_VRC7 = 0

--- a/SoundEngine/famistudio_nesasm.asm
+++ b/SoundEngine/famistudio_nesasm.asm
@@ -114,7 +114,10 @@ FAMISTUDIO_NESASM_CODE_ORG     = $8000
 ;======================================================================================================================
 
 ; Konami VRC6 (2 extra square + saw)
-; FAMISTUDIO_EXP_VRC6          = 1 
+; FAMISTUDIO_EXP_VRC6          = 1
+
+; Rainbow-Net (homebrew clone of VRC6)
+; FAMISTUDIO_EXP_RAINBOW       = 1
 
 ; Konami VRC7 (6 FM channels)
 ; FAMISTUDIO_EXP_VRC7          = 1 
@@ -267,6 +270,14 @@ FAMISTUDIO_DPCM_OFF = $c000
 ;======================================================================================================================
 ; INTERNAL DEFINES (Do not touch)
 ;======================================================================================================================
+
+    .ifndef FAMISTUDIO_EXP_RAINBOW
+FAMISTUDIO_EXP_RAINBOW = 0
+    .endif
+
+    .if FAMISTUDIO_EXP_RAINBOW
+FAMISTUDIO_EXP_VRC6 = 1
+    .endif
 
     .ifndef FAMISTUDIO_EXP_VRC6
 FAMISTUDIO_EXP_VRC6 = 0
@@ -1066,6 +1077,17 @@ FAMISTUDIO_APU_DMC_LEN    = $4013
 FAMISTUDIO_APU_SND_CHN    = $4015
 FAMISTUDIO_APU_FRAME_CNT  = $4017
 
+    .if FAMISTUDIO_EXP_RAINBOW
+FAMISTUDIO_VRC6_PL1_VOL   = $41a0
+FAMISTUDIO_VRC6_PL1_LO    = $41a1
+FAMISTUDIO_VRC6_PL1_HI    = $41a2
+FAMISTUDIO_VRC6_PL2_VOL   = $41a3
+FAMISTUDIO_VRC6_PL2_LO    = $41a4
+FAMISTUDIO_VRC6_PL2_HI    = $41a5
+FAMISTUDIO_VRC6_SAW_VOL   = $41a6
+FAMISTUDIO_VRC6_SAW_LO    = $41a7
+FAMISTUDIO_VRC6_SAW_HI    = $41a8
+    .else
 FAMISTUDIO_VRC6_PL1_VOL   = $9000
 FAMISTUDIO_VRC6_PL1_LO    = $9001
 FAMISTUDIO_VRC6_PL1_HI    = $9002
@@ -1075,6 +1097,7 @@ FAMISTUDIO_VRC6_PL2_HI    = $a002
 FAMISTUDIO_VRC6_SAW_VOL   = $b000
 FAMISTUDIO_VRC6_SAW_LO    = $b001
 FAMISTUDIO_VRC6_SAW_HI    = $b002
+    .endif
 
 FAMISTUDIO_VRC7_SILENCE   = $e000
 FAMISTUDIO_VRC7_REG_SEL   = $9010


### PR DESCRIPTION
Rainbow net is an upcoming homebrew mapper supporting MMC5-like features, but with VRC6 audio. (Documentation here: https://github.com/BrokeStudio/rainbow-net/tree/master/NES )

There are a few other audio features like global volume control, but those don't need to be supported in famistudio afaict.