### PR TITLE
Make German Translations

### DIFF
--- a/FamiStudio/Localization/FamiStudio.deu.ini
+++ b/FamiStudio/Localization/FamiStudio.deu.ini
@@ -164,10 +164,10 @@ SetActiveChannelPrefix=kanal {0} Aktivieren
 ForceDisplayPrefix=Kanal {0} Anzeigen
 
 [PropertyPage]
-NameLabel=Name #TODO!
-ColorLabel=Color #TODO!
-AdvancedPropsLabel=Advanced Properties #TODO!
-AdvancedPropsTooltip=These properties are meant for more advanced users #TODO!
+NameLabel=Name
+ColorLabel=Farbe
+AdvancedPropsLabel=Andere Eigenschaften
+AdvancedPropsTooltip=Diese Eigenschaften sind für erfahrene Nutzer.
 
 [ExportDialog]
 
@@ -652,7 +652,7 @@ DeleteUnusedArpeggiosLabel=Lösche ungenutzte Arpeggios
 # Tooltips
 TempoTooltip=Dies ist nicht BPM! Es ist die Rate des internen Tempozählers. Andere Werte als 150 können zu ungleichmäßig langen Noten führen. Please see FamiTracker documentation.
 SpeedTooltip=If tempo is 150, number of NTSC frames (1/60th of a second) between each notes.  Höhere Werte führen zu einem langsameren Tempo. Please see FamiTracker documentation.
-BPMTooltip=Schläge pro Minute (BPM). #TODO!
+BPMTooltip=Schläge pro Minute (BPM).
 FramesPerNoteTooltip=Anzahl an Frames (1/60th of a second in NTSC, 1/50th in PAL) in einer Note. Dies wird automatisch mit der BPM ausgerechnet.
 NotesPerPatternTooltip=Anzahl der Noten in einem Muster. Ein Muster ist die kleinste einheit eines Tracks den du öfters wiederholen kannst. Dies kann mit der BPM genutzt werden, um Taktarten zu replizieren. \n\nBeispielwerte für gängige Taktarten falls du 1 bar per pattern möchtest, mit einem 'Notes per Beat’ oder 4 (standart):\n\n  2/4 : 8\n  3/4 : 12\n  4/4 : 16\n  5/4 : 20\n  6/8 = 24 (dann BPM verdoppeln)\n  2/2 = 8 (dann BPM halbieren)\n\nNatürlich kannst du immer diese Zahlen verdoppeln, um zwei takte in ein Muster zu machen. #TODO!
 NotesPerBeatTooltip=Anzahl der Noten in einem Beat. Eine Dunklere linie wird zwischen Beats gezogen. Wirkt auf BPM Kalkulation ein.\n\nEs ist SEHR empfohlen, dass dies auf 4 gelassen wird.
@@ -744,12 +744,12 @@ AccurateSeekLabel=Vollständige Emulation bei Seeking
 AccurateSeekTooltip=Genaue Emulation ab dem Beginn des Songs\nDies ist langsamer, verbessert aber die Genauigkeit von zeitempfindlichen Effekten wie Phasen-Resets
 
 # Help dialog
-ShowHelpTitle=Help #TODO!
-ShowHelpLabel=Open online documentation? #TODO!
+ShowHelpTitle=Hilfe
+ShowHelpLabel=Online Dokumentation öffnen?
 
 [Timecode]
-FormatMinSecMs=Minutes:Seconds:Milliseconds #TODO!
-FormatPatternFrame=Pattern:Frame #TODO!
+FormatMinSecMs=Minuten:Sekunded:Millisekunden
+FormatPatternFrame=Muster:Frame
 
 [Sequencer]
 
@@ -811,7 +811,7 @@ CustomPatternTooltip=Aktivieren, um unterschiedliche Längen und/oder Tempo-Para
 
 # Pattern properties dialog
 PatternPropertiesTitle=Eigenschaften des Musters
-#MultiplePatternsSelectedLabel=[Multiple Patterns Selected] #TODO!
+#MultiplePatternsSelectedLabel=[Mehrere Muster ausgewählt] #TODO!
 ErrorRenamingPattern=Fehler beim Benennen des Musters!
 
 [FamiStudio]
@@ -997,8 +997,8 @@ CopyInstrumentSamplesMessage=Sind Sie sich sicher, dass Sie die DPCM-Sample-Zuwe
 CopyInstrumentSamplesTitle=DPCM-Zuweisungen Kopieren
 
 [ParamControl]
-EnterValueContext=Enter Value... #TODO!
-ResetDefaultValueContext=Reset Default Value #TODO!
+EnterValueContext=Wert Eingeben...
+ResetDefaultValueContext=Zurücksetzten
 
 [DPCMSampleRate]
 KHzLabel=kHz
@@ -1009,8 +1009,8 @@ HzLabel=Hz
 PitchLabel=Tonhöhe
 VolumeLabel=Lautstrk.
 DutyLabel=Duty
-WaveOverlap=Wave overlap detected! #TODO!
-WaveWrongPlaying=Potentially wrong wave playing! #TODO!
+WaveOverlap=Wellnüberlappung Entdeckt!
+WaveWrongPlaying=Potential falsche Welle!
 
 [ApuRegisterViewer]
 ModeLabel=Modus
@@ -1051,8 +1051,8 @@ VolOP3Label=Vol OP3
 VolOP4Label=Vol OP4
 
 [N163RegisterViewer]
-WavePosLabel=Wav Pos #TODO!
-WaveSizeLabel=Wav Size #TODO!
+WavePosLabel=Wellenposition
+WaveSizeLabel=Wellengröße
 
 [PianoRoll]
 
@@ -1274,8 +1274,8 @@ RepeatLabel=Wiederholen #TODO!
 RepeatTooltip=Anzahl an Wiederholungen vom Einfügen. #TODO!
 
 [Grid]
-SelectAllLabel=Select All
-SelectNoneLabel=Select None
+SelectAllLabel=Alle Auswählen
+SelectNoneLabel=Keine Auswählen
 
 [InstrumentParamProvider]
 
@@ -1288,7 +1288,7 @@ OffLabel=Aus
 # FDS/N163
 MasterVolumeLabel=Gesamtlautstärke
 WavePresetLabel=Wellen Voreinstellung
-WaveAutoPosLabel=Wave Auto-Position #TODO!
+WaveAutoPosLabel=Wellen Autoposition
 WavePositionLabel=Wellenposition
 WaveSizeLabel=Wellengröße
 WaveCountLabel=Wellenanzahl
@@ -1437,7 +1437,7 @@ VideoPreviewLabel=Videovorschau
 VideoPreviewTooltip=Die Vorschau wird in Kürze abgespielt, Bei Songs mit vielen Kanälen dauert der Start länger. Diese Vorschau enthält keinen Ton und keine Komprimierung. Die Bildrate ist möglicherweise nicht sehr genau und die Auflösung ist niedriger als die des echten Videos.
 
 [DropDown]
-SelectValueLabel=Select Value #TODO!
+SelectValueLabel=Wert Auswählen
 
 [MixerProperties]
 ; Labels
@@ -1461,15 +1461,15 @@ GlobalGridTooltip=Die globale Lautstärke (in dB), welche auf alle Audio angewen
 ExpansionGridTooltip=Das Volumen (in dB), Die Menge an Treble (in dB) und die Frequenz, ab der das Treble reduziert wird (in Hz) für jede Expansion.
 
 [FamiStudioWindow]
-EnterTextLabel=Enter Text #TODO!
-YesButton=Yes #TODO!
-NoButton=No #TODO!
-CancelButton=Cancel #TODO!
-OKButton=OK #TODO!
+EnterTextLabel=Text Eingeben
+YesButton=Ja
+NoButton=Nein
+CancelButton=Abbrechen
+OKButton=OK
 
 [CheckBoxList]
-SelectAllLabel=Select All #TODO!
-SelectNoneLabel=Select None #TODO!
+SelectAllLabel=Alle Auswählen
+SelectNoneLabel=Keine Auswählen
 
 [LogTextBox]
-CopyLogTextContext=Copy log text #TODO!
+CopyLogTextContext=Log-text Kopieren


### PR DESCRIPTION
I noticed that BPMToolTip had a TODO Label, even though it was already translated. I removed the TODO, just for clarity