### PR TITLE
Updated PT-BR translation

### DIFF
--- a/FamiStudio/Localization/FamiStudio.por.ini
+++ b/FamiStudio/Localization/FamiStudio.por.ini
@@ -1472,4 +1472,4 @@ SelectAllLabel=Selecionar todos
 SelectNoneLabel=Selecionar nenhum
 
 [LogTextBox]
-CopyLogTextContext=Copy texto do log
+CopyLogTextContext=Copiar texto do log

--- a/FamiStudio/Localization/FamiStudio.por.ini
+++ b/FamiStudio/Localization/FamiStudio.por.ini
@@ -71,7 +71,7 @@ LocalizedNames_43=Rimshot # EPSM
 
 [EnvelopeType]
 LocalizedNames_0=Volume
-LocalizedNames_1=Arpeggio
+LocalizedNames_1=Arpejo
 LocalizedNames_2=Tom
 LocalizedNames_3=Duty Cycle
 LocalizedNames_4=Onda FDS
@@ -164,10 +164,10 @@ SetActiveChannelPrefix=Estabelecer Canal Ativo {0}
 ForceDisplayPrefix=Forçar Visualização do Canal {0}
 
 [PropertyPage]
-NameLabel=Name #TODO!
-ColorLabel=Color #TODO!
-AdvancedPropsLabel=Advanced Properties #TODO!
-AdvancedPropsTooltip=These properties are meant for more advanced users #TODO!
+NameLabel=Nome
+ColorLabel=Cor
+AdvancedPropsLabel=Propriedades avançadas
+AdvancedPropsTooltip=Essas propriedades são para usuários avançados!
 
 [ExportDialog]
 
@@ -318,7 +318,7 @@ InstrumentModeLabel=Modo de Instrumento
 InstrumentsLabels=Instrumentos
 
 # FamiStudio Text tooltips
-DeleteUnusedTooltip=Se ativado, deletará qualquer dado não utilizado (instrumento, arpeggio, amostra DPCM, etc.) antes da exportação.
+DeleteUnusedTooltip=Se ativado, deletará qualquer dado não utilizado (instrumento, arpejo, amostra DPCM, etc.) antes da exportação.
 
 # FamiStudio Text labels
 DeleteUnusedDataLabel=Deletar dados não utilizados
@@ -554,19 +554,19 @@ AuthorLabel=Autor
 CopyrightLabel=Copyright
 TempoModeLabel=Modo de Tempo
 MachineLabel=Máquina de Autoria
-TuningLabel=Tuning #TODO!
+TuningLabel=Afinamento
 
 # Information tooltips
 TempoModeTooltip=Tempo FamiStudio lhe dá controle preciso sobre cada quadro, tem bom suporte para conversão PAL/NTSC e é a maneira recomendada de se usar o FamiStudio. Tempo FamiTracker age como o FamiTracker com configurações de velocidade/tempo. Use somente se você tiver necessidades de compatibilidade específicas, já que o suporte é limitado e não oferecerá a melhor experiência FamiStudio.
 AuthoringMachineTooltip=Para uso com o tempo FamiStudio. Define a máquina em que a música é editada. Reprodução para o outro tipo será aproximada, mas ainda boa.
-TuningTooltip=Frequency (in Hz) of A. The standard, concert pitch, is A = 440 Hz. #TODO!
+TuningTooltip=Frequência (em Hz) de A (Lá). O tom de concerto padrão é A = 440 Hz.
 
 # Expansion labels
 N163ChannelsLabel=Canais N163
 ExpansionLabel=Expansões de Áudio
 
 # Expansion tooltips
-ExpansionAudioTooltip=Chips de expansão de áudio usados. Adicionará canais extras e irá desativar o suporte para PAL. #TODO!
+ExpansionAudioTooltip=Chips de expansão de áudio usados. Adicionará canais extras.
 ExpansionNumChannelsTooltip=Áudio Namco 163 suporta entre 1 e 8 canais. A qualidade do áudio deteriora a medida que você adiciona mais canais. Só disponível quando a expansão 'Namco 163' estiver ativada.
 
 # Expansion warnings
@@ -589,7 +589,7 @@ ExtendedInstrumentTooltip=Quando ativado, permite usar até 256 instrumentos bas
 UserProjectsSaveTooltip=Estes são os seus projetos. Selecione um para sobrescrevê-lo. Para salvar em um novo arquivo de projeto, selecione a última opção e digite um nome.
 UserProjectsLoadTooltip=Estes são os seus projetos. Selecione um para carregá-lo.
 DemoProjectsLoadTooltip=Estes são projetos demo que vem com o FamiStudio. Eles são ótimos recursos para se aprender.
-OpenFromStorageTooltip=Isso irá pedi-lo para escolher um arquivo no armazenamento do seu dispositivo. Você pode abrir arquivos .FMS FamiStudio, além de outros formatos como NSF, FTM FamiTracker ou arquivos TXT. #TODO!
+OpenFromStorageTooltip=Isso irá pedi-lo para escolher um arquivo no armazenamento do seu dispositivo. Você pode abrir arquivos .FMS FamiStudio, além de outros formatos como NSF, FTM FamiTracker ou arquivos TXT. Para instrumentos, também podem ser selecionados arquivos FTI, BTI e OPNI.
 UserProjectsLabel=Projetos do Usuário
 NewProjectNameLabel=Novo Nome de Projeto
 NewProjectNameTooltip=Digite o nome do novo projeto.
@@ -636,7 +636,7 @@ UnassignUnusedSamplesTooltip=Remove amostras dos 'Instrumento DPCM' que não sã
 DeleteUnassignedSamplesTooltip=Deleta amostras DPCM que não foram designadas a uma nota no 'Instrumento DPCM'.
 PermanentlyApplyProcessingTooltip=Para cada amostra DPCM que usa processamento (ajuste de volume, etc.), os aplicará permanentemente aos dados DMC e o fará os dados-fonte. Apenas faça isso você tem certeza que terminou de ajustá-los. Para amostras que usam arquivos WAV como fonte, isso pode tornar seu projeto muito menor.
 DiscardN163FdsResampleWavTooltip=Descarta qualquer dado fonte para instrumentos FDS/N163 que são reamostrados de um arquivo WAV. Você pode fazer isto para diminuir o tamanho do seu projeto quando tiver acabado de ajustar os parâmetros de reamostramento.
-DeleteUnusedArpeggiosTooltip=Deleta qualquer arpeggio que não é usado em nenhum lufar no projeto.
+DeleteUnusedArpeggiosTooltip=Deleta qualquer arpejo que não é usado no projeto.
 
 # Project labels
 DeleteUnusedInstrumentsLabel=Deletar instrumentos não utilizados
@@ -645,16 +645,16 @@ UnassignUnusedSamplesLabel=Remover teclas não utilizadas do instrumento DPCM
 DeleteUnassignedSamplesLabel=Deletar amostras não designadas
 PermanentlyApplyProcessingLabel=Aplicar permanentemente o processamento às amostras DPCM
 DiscardN163FdsResampleWavLabel=Descartar dados WAV reamostrados para FDS/N163
-DeleteUnusedArpeggiosLabel=Deletar arpeggios não utilizados
+DeleteUnusedArpeggiosLabel=Deletar arpejos não utilizados
 
 [TempoProperties]
 
 # Tooltips
 TempoTooltip=Isto não é o BPM! É a taxa na qual o contador de tempo interno é incrementado. Valores diferentes de 150 podem resultar em notas desiguais. Por favor veja a documentação do FamiTracker.
 SpeedTooltip=Se o tempo é 150, número de quadros NTSC (1/60° de um segundo) entre cada nota. Valores maiores resultam em um tempo mais devagar. Por favor veja a documentação do FamiTracker.
-BPMTooltip=Batidas por minuto. #TODO!
+BPMTooltip=Batidas por minuto.\n\nValores com asteriscos (*) são os recomendados e soarão mais normais, já que usam um número fixo de quadros.
 FramesPerNoteTooltip=Número de quadros (1/60° de um segundo em NTSC, 1/50° em PAL) em uma nota. Isto e computado automaticamente através das BPM.
-NotesPerPatternTooltip=Número de notas em um padrão. Um padrão é a menor unidade possível de sua música que você talvez queira repetir múltiplas vezes. Isto, combinado com as 'Notas por Batida', pode ser usado para atingir compassos musicais.\n\nConfigurações para compassos comuns se você desejar 1 barra por padrão, assumindo uma 'Notas por Batida' de 4 (padrão):\n\n  2/4 : 8\n  3/4 : 12\n  4/4 : 16\n  5/4 : 20\n  6/8 = 24 (e dobre o BPM)\n  2/2 = 8 (e divida o BPM ao meio)\n\nE claro, você sempre pode dobrar estes números para encaixar 2 barras em um padrão. #TODO!
+NotesPerPatternTooltip=Número de notas em um padrão. Um padrão é a menor unidade possível de sua música que você talvez queira repetir múltiplas vezes. Isto, combinado com as 'Notas por Batida', pode ser usado para atingir compassos musicais.\n\nConfigurações para compassos comuns caso deseje 1 barra por padrão, assumindo uma 'Notas por Batida' de 4 (padrão):\n\n  2/4 : 8\n  3/4 : 12\n  4/4 : 16\n  5/4 : 20\n  6/8 = 24 (e dobre o BPM)\n  2/2 = 8 (e divida o BPM ao meio)\n\nE claro, você sempre pode dobrar estes números para encaixar 2 barras em um padrão.
 NotesPerBeatTooltip=Número de notas em uma batida. Uma linha mais escura será desenhada entre as batidas no piano roll. Afeta o cálculo do BPM.\n\nÉ ALTAMENTE recomendado que você deixe isto no valor padrão de 4.
 GrooveTooltip=A sequência de contagens de quadro que serão executadas para atingir os BPMs desejados.
 GroovePaddingTooltip=Determina onde será injetado um quadro vazio quando o valor de groove é maior do que o número de quadros em uma nota.
@@ -744,12 +744,12 @@ AccurateSeekLabel=Emular completamente quando reproduzir
 AccurateSeekTooltip=Emula precisamente do início da música toda vez que reproduzir. Mais lento, mas aumenta a precisão de efeitos como resets de fase.
 
 # Help dialog
-ShowHelpTitle=Help #TODO!
-ShowHelpLabel=Open online documentation? #TODO!
+ShowHelpTitle=Ajuda
+ShowHelpLabel=Abrir documentação online?
 
 [Timecode]
-FormatMinSecMs=Minutes:Seconds:Milliseconds #TODO!
-FormatPatternFrame=Pattern:Frame #TODO!
+FormatMinSecMs=Minutos:Segundos:Milissegundos
+FormatPatternFrame=Padrão:Quadro
 
 [Sequencer]
 
@@ -792,7 +792,7 @@ DeletePatternLabel=Deletar Padrão
 # Dialogs
 PasteTitle=Colar
 PasteMissingInstrumentsMessage=Você esta colando notas que se referem a instrumentos desconhecidos. Você quer criar o instrumento faltante?
-PasteMissingArpeggiosMessage=Você esta colando notas que se referem a arpeggios desconhecidos. Você quer criar o arpeggio faltante?
+PasteMissingArpeggiosMessage=Você esta colando notas que se referem a arpejos desconhecidos. Você quer criar o arpejo faltante?
 PasteMissingSamplesMessage=Você esta colando notas que se referem a amostras desconhecidas. Você quer criar a amostra faltante?
 
 # Paste special dialog
@@ -811,7 +811,7 @@ CustomPatternTooltip=Ativa o uso de parâmetros de tempo e tamanho diferentes pa
 
 # Pattern properties dialog
 PatternPropertiesTitle=Propriedades do Padrão
-#MultiplePatternsSelectedLabel=[Multiple Patterns Selected] #TODO!
+MultiplePatternsSelectedLabel=[Múltiplos padrões selecionados]
 ErrorRenamingPattern=Erro renomeando padrão!
 
 [FamiStudio]
@@ -829,7 +829,7 @@ NoLastExportWarning=Sem última exportação para repetir
 ProjectChangedExportWarning=O projeto mudou demais para se repetir a última exportação.
 NewVersionToast=Uma nova versão ({0}) está disponível. Clique aqui para baixar!
 NewProjectTitle=Novo Projeto
-NewVersionWelcome=Welcome to FamiStudio {0}, click here to see what's new! #TODO!
+NewVersionWelcome=Bem-vindo(a) ao FamiStudio {0}! Clique aqui para ver o que há de novo.
 IncompatibleInstrumentError=Instrumento selecionado é incompatível com o canal!
 IncompatibleExpRequiredError=Canais de expansão requerem o uso do tipo de instrumento correto.
 AudioDeviceChanged=Mudança de dispositivo de áudio detectada
@@ -843,16 +843,16 @@ TabNames_1=Registros
 SongsHeaderLabel=Músicas
 InstrumentHeaderLabel=Instrumentos
 SamplesHeaderLabel=Amostras DPCM
-ArpeggiosHeaderLabel=Arpeggios
+ArpeggiosHeaderLabel=Arpejos
 ArpeggioNoneLabel=Nenhum
 RegistersExpansionHeaderLabel=Registros {0}
 
 # Tooltips
-AddNewArpeggioTooltip=Adicionar novo arpeggio
+AddNewArpeggioTooltip=Adicionar novo arpejo
 AddNewInstrumentTooltip=Adicionar novo instrumento
 AddNewSongTooltip=Adicionar nova música
-AddNewSampleTooltip=Add new DPCM sample folder #TODO!
-AutoSortArpeggioActiveTooltip=Organização automática dos arpeggios está ativa, {0} para mudar
+AddNewSampleTooltip=Adicionar nova pasta de amostras DPCM
+AutoSortArpeggioActiveTooltip=Organização automática dos arpejos está ativa, {0} para mudar
 AutoSortInstrumentActiveTooltip=Organização automática dos instrumentos está ativa, {0} para mudar
 AutoSortSampleActiveTooltip=Organização automática das amostras DPCM está ativa, {0} para mudar
 AutoSortSongActiveTooltip=Organização automática das músicas está ativa, {0} para mudar
@@ -863,7 +863,7 @@ CopyReplaceInstrumentTooltip=Copiar/Substituir instrumento
 EditEnvelopeTooltip=Editar envelope {0}
 EditSamplesTooltip=Editar amostras DPCM
 EditWaveformTooltip=Editar onda
-EditArpeggioTooltip=Edit Arpeggio #TODO!
+EditArpeggioTooltip=Editar Arpejo
 ImportInstrumentsTooltip=Importar/fundir instrumento(s) de outro projeto
 ImportSamplesTooltip=Carregar amostra DPCM de um arquivo WAV ou DMC
 ImportSongsTooltip=Importar/fundir música(s) de outro projeto
@@ -871,23 +871,23 @@ MakeSongCurrentTooltip=Tornar em música atual
 MoreOptionsTooltip=Mais Opções...
 PlaySourceSampleTooltip=Reproduzir amostra fonte
 PreviewProcessedSampleTooltip=Pré-visualizar amostra DPCM processada
-PropertiesArpeggioTooltip=Propriedades do arpeggio
+PropertiesArpeggioTooltip=Propriedades do arpejo
 PropertiesInstrumentTooltip=Propriedades do instrumento
 PropertiesProjectTooltip=Propriedades do projeto
 PropertiesSongTooltip=Propriedades da música/tempo
 PropertiesFolderTooltip=Propriedades da pasta
 ReloadSourceDataTooltip=Recarregar dados fonte (se disponíveis)\nApenas possível caso os dados foram carregados de um arquivo DMC/WAV
 ReorderSongsTooltip=Reordenar música
-ReplaceArpeggioTooltip=Substituir arpeggio
-SelectArpeggioTooltip=Selecionar arpeggio
+ReplaceArpeggioTooltip=Substituir arpejo
+SelectArpeggioTooltip=Selecionar arpejo
 SelectInstrumentTooltip=Selecionar instrumento
 ToggleValueTooltip=Alternar valor
 AllowProjectMixerSettings=Permite que o projeto modifique as opções de mixer do app (volume, filtragem, etc.).\nAtivar isto não muda as configurações do projeto.
-ExpandTooltip=Expand section #TODO!
+ExpandTooltip=Expandir seção
 
 # Messages
-CopyArpeggioMessage=Você tem certeza que quer copiar os valores de arpeggio de '{0}' para '{1}'?
-CopyArpeggioTitle=Copiar Arpeggio
+CopyArpeggioMessage=Você tem certeza que quer copiar os valores do arpejo de '{0}' para '{1}'?
+CopyArpeggioTitle=Copiar Arpejo
 ErrorTitle=Erro
 MaxWavFileWarning=O tamanho máximo suportado para um arquivo WAV é de {0} segundos. Cortando.
 MaxDmcSizeWarning=O tamanho máximo para um arquivo DMC é de {0} bytes. Cortando.
@@ -896,16 +896,16 @@ AskDeleteSongMessage=Você tem certeza que quer deletar '{0}'?
 AskDeleteSongTitle=Deletar música
 AskDeleteInstrumentMessage=Você tem certeza que quer deletar '{0}' ? Todas as notas que usam este instrumento serão deletadas.
 AskDeleteInstrumentTitle=Deletar instrumento
-AskDeleteArpeggioMessage=Você tem certeza que quer deletar '{0}' ? Todas as notas que usam este arpeggio não serão arpeggiadas mais.
-AskDeleteArpeggioTitle=Deletar arpeggio
+AskDeleteArpeggioMessage=Você tem certeza que quer deletar '{0}' ? Todas as notas que usam este arpejo não serão arpejadas mais.
+AskDeleteArpeggioTitle=Deletar arpejo
 AskDeleteSampleMessage=Você tem certeza que quer deletar a amostra DPCM '{0}' ? Ela será removida do Instrumento DPCM e todas as notas que a usavam não produzirão som mais.
 AskDeleteSampleTitle=Deletar Amostra DPCM
 AskDeleteFolderMessage=Deletar pasta '{0}' e todos os seus itens? Selecionar 'Não' irá deletar a pasta mas manter seus itens.
 AskDeleteFolderTitle=Deletar pasta
 AskReplaceInstrumentMessage=Selecione o instrumento para ser usado na substituição. Todas as notas usando '{0}' serão trocadas pelo instrumento selecionado.
 AskReplaceInstrumentTitle=Substituir Instrumento
-AskReplaceArpeggioMessage=Selecione o arpeggio para ser usado na substituição. Todas as notas usando '{0}' serão trocadas pelo arpeggio selecionado.
-AskReplaceArpeggioTitle=Substituir Arpeggio
+AskReplaceArpeggioMessage=Selecione o arpejo para ser usado na substituição. Todas as notas usando '{0}' serão trocadas pelo arpejo selecionado.
+AskReplaceArpeggioTitle=Substituir Arpejo
 ClipboardNoValidTextError=Nenhum texto válido encontrado na área de transferência
 ClipboardInvalidNumberRegisters=Número de registros inválido
 CantFindSourceFileError=Não foi possível encontrar o arquivo-fonte '{0}'!
@@ -946,8 +946,8 @@ InstrumentPropertiesTitle=Propriedades do Instrumento
 RenameInstrumentError=Erro renomeando instrumento!
 
 # Arpeggio properties dialog
-ArpeggioPropertiesTitle=Propriedades do Arpeggio
-RenameArpeggioError=Erro renomeando arpeggio!
+ArpeggioPropertiesTitle=Propriedades do Arpejo
+RenameArpeggioError=Erro renomeando arpejo!
 
 # DPCM sample properties dialog
 SamplePropertiesTitle=Propriedades da Amostra DPCM
@@ -959,14 +959,14 @@ RenameFolderError=Erro renomeando pasta!
 
 # Context menus
 AddSongContext=Adicionar Música
-AddArpeggioContext=Adicionar Arpeggio
+AddArpeggioContext=Adicionar Arpejo
 AddFolderContext=Adicionar Nova Pasta
 AddExpInstrumentContext=Adicionar Novo Instrumento {0}
 AddRegularInstrumentContext=Adicionar Novo Instrumento Regular
 AutoAssignBanksContext=Auto-Designar Bancos...
 ClearEnvelopeContext=Limpar Envelope
 CopyRegisterValueContext=Copiar Valores do Registro como Texto
-DeleteArpeggioContext=Deletar Arpeggio
+DeleteArpeggioContext=Deletar Arpejo
 DeleteInstrumentContext=Deletar Instrumento
 DeleteSampleContext=Deletar Amostra DPCM
 DeleteSongContext=Deletar Música
@@ -979,12 +979,12 @@ DuplicateConvertContext=Duplicar e Converter para {0}
 ExportProcessedDmcDataContext=Exportar Dados DMC Processados...
 ExportSourceDataContext=Exportar Dados Fonte...
 PasteRegisterValueContext=Colar Valores do Registro como Texto
-PropertiesArpeggioContext=Propriedades do Arpeggio...
+PropertiesArpeggioContext=Propriedades do Arpejo...
 PropertiesInstrumentContext=Propriedades do Instrumento...
 PropertiesProjectContext=Propriedades do Projeto...
 PropertiesSamplesContext=Propriedades da Amostra DPCM...
 PropertiesSongContext=Propriedades da Música...
-PropertiesFolderContext=Folder Properties... #TODO!
+PropertiesFolderContext=Propriedades da Pasta...
 ReplaceWithContext=Substituir Por...
 ResampleWavContext=Reamostrar Arquivo WAV...
 CollapseAllContext=Colapsar Todas as Pastas
@@ -997,8 +997,8 @@ CopyInstrumentSamplesMessage=Você tem certeza que quer copiar as designações 
 CopyInstrumentSamplesTitle=Copiar Designações DPCM
 
 [ParamControl]
-EnterValueContext=Enter Value... #TODO!
-ResetDefaultValueContext=Reset Default Value #TODO!
+EnterValueContext=Coloque um valor...
+ResetDefaultValueContext=Resetar para o valor padrão
 
 [DPCMSampleRate]
 KHzLabel=kHz
@@ -1009,8 +1009,8 @@ HzLabel=Hz
 PitchLabel=Tom
 VolumeLabel=Volume
 DutyLabel=Duty
-WaveOverlap=Wave overlap detected! #TODO!
-WaveWrongPlaying=Potentially wrong wave playing! #TODO!
+WaveOverlap=Sobreposição de ondas detectada!
+WaveWrongPlaying=Onda potencialmente errada tocando!
 
 [ApuRegisterViewer]
 ModeLabel=Modo
@@ -1051,15 +1051,15 @@ VolOP3Label=Vol OP3
 VolOP4Label=Vol OP4
 
 [N163RegisterViewer]
-WavePosLabel=Wav Pos #TODO!
-WaveSizeLabel=Wav Size #TODO!
+WavePosLabel=Posição da Onda
+WaveSizeLabel=Tamanho da Onda
 
 [PianoRoll]
 
 # Piano Roll
 EditingChannelLabel=Editando canal {0}
 EditingDPCMSampleLabel=Editando Amostra DPCM {0}
-EditingArpeggioLabel=Editando Arpeggio {0}
+EditingArpeggioLabel=Editando Arpejo {0}
 EditingInstrumentEnvelopeLabel=Editando Instrumento {0} ({1})
 EditingInstrumentDPCMLabel=Editando Instrumento {0} (Amostras DPCM)
 DPCMSourceDataLabel=Dados Fonte ({0}) : {1} Hz, {2} Bytes, {3} ms
@@ -1067,9 +1067,9 @@ DPCMProcessedDataLabel=Dados Processados (DMC) : {0}, {1} Bytes, {2} ms
 DPCMPreviewPlaybackLabel=Pré-visualizar Reprodução : {0}, {1} ms
 DPCMInstrumentUsageLabel={0} / {1} bytes usados por este instrumento
 InstrumentNotSelectedLabel=Aviso : O instrumento não está atualmente selecionado. O instrumento selecionado '{0}' será ouvido quando tocar o piano.
-ArpeggioOverriddenLabel=Aviso : Envelope do arpeggio atualmente anulado pelo arpeggio selecionado '{0}'
-ArpeggioNotSelectedLabel=Warning : Arpeggio não está atualmente selecionado.
-SelectedArpeggioWillBeHeardLabel=O arpeggio selecionado '{0}' será ouvido quando tocar o piano.
+ArpeggioOverriddenLabel=Aviso : Envelope do arpejo atualmente anulado pelo arpejo selecionado '{0}'
+ArpeggioNotSelectedLabel=Warning : Arpejo não está atualmente selecionado.
+SelectedArpeggioWillBeHeardLabel=O arpejoio selecionado '{0}' será ouvido quando tocar o piano.
 DPCMBankUsageLabel={0} bytes usados no banco {1}
 RelativeEffectScalingLabel=Escalamento do valor de efeito relativo selecionado.
 EnvelopeRelativeLabel=Relativo
@@ -1099,7 +1099,7 @@ DMCInitialValueDiv2Label=Valor Inicial DMC (÷2)
 # Paste messages
 PasteTitle=Colar
 PasteMissingInstrumentsMessage=Você está colando notas que se referem a instrumentos desconhecidos. Você quer criar o instrumento faltante?
-PasteMissingArpeggiosMessage=Você está colando notas que se referem a arpeggios desconhecidos. Você quer criar o arpeggio faltante?
+PasteMissingArpeggiosMessage=Você está colando notas que se referem a arpejos desconhecidos. Você quer criar o arpejo faltante?
 PasteMissingSamplesMessage=Você está colando notas que se referem a amostras desconhecidas. Você quer criar a amostra faltante?
 
 # Context menus
@@ -1191,7 +1191,7 @@ SamplePropertiesTooltip=Propriedades da amostra
 SamplesSelectedTooltip={0} amostra(s) selecionada(s)
 ValuesSelectedTooltip={0} valor(es) selecionado(s)
 FramesSelectedTooltip={0} quadro(s) selecionado(s)
-ArpeggioTooltip=Arpeggio
+ArpeggioTooltip=Arpejo
 
 [QuickAccessBar]
 
@@ -1209,7 +1209,7 @@ SnapOffLabel=Desligado
 
 # Context menus
 ReplaceSelectionInstContext=Substituir Instrumento na Seleção
-ReplaceSelectionArpContext=Substituir Arpeggio na Seleção
+ReplaceSelectionArpContext=Substituir Arpejo na Seleção
 ToggleMuteContext=Ativar/Desativar Canal Mudo
 ToggleSoloContext=Ativar/Desativar Canal Solo
 ToggleForceDisplayContext=Force Display Channel in Piano Roll
@@ -1232,7 +1232,7 @@ ChannelMappingLabel=Mapeamento de canais
 NESChannelColumn=Canal NES
 MIDISourceColumn=Fonte MIDI
 Channel10KeysColumn=Canal 10 teclas
-MIDIDisclaimerLabel=Alerta : O NES não pode tocar múltiplas notas no mesmo canal, qualquer tipo de polifonia não é suportada. Arquivos MIDI devem ser devidamente selecionados. Além disso, apenas instrumentos vazios serão criados e não soarão nada como seus equivalentes MIDI. #TODO!
+MIDIDisclaimerLabel=Alerta : O NES não pode tocar múltiplas notas no mesmo canal. Arquivos MIDI devem ser devidamente formatados para remover qualquer polifonia. Além disso, apenas instrumentos vazios serão criados e não soarão nada como seus equivalentes MIDI.
 SourceNoneOption=Nenhum (Deixar o canal vazio)
 SourceChannelPrefix=Canal
 SourceTrackPrefix=Faixa
@@ -1288,7 +1288,7 @@ OffLabel=Desligado
 # FDS/N163
 MasterVolumeLabel=Volume Master
 WavePresetLabel=Preset de Onda
-WaveAutoPosLabel=Wave Auto-Position #TODO!
+WaveAutoPosLabel=Auto-posicionamento da Onda
 WavePositionLabel=Posição da Onda
 WaveSizeLabel=Tamanho da Onda
 WaveCountLabel=Contagem de Ondas
@@ -1410,7 +1410,7 @@ TutorialMessages_8=(9/12) SNAPPING está ATIVADO por padrão e é expressado em 
 TutorialMessages_9=(10/12) Para ver a DOCUMENTAÇÃO completa e o VÍDEO TUTORIAL, por favor clique no grande PONTO DE INTERROGAÇÃO.
 TutorialMessages_10=(11/12) Usar BLUETOOTH adiciona muita LATÊNCIA DE ÁUDIO (delay no áudio). Infelizmente não há nada que o FamiStudio possa fazer sobre isso. Fones com fio ou alto-falantes terão uma LATÊNCIA muito menor.
 TutorialMessages_11=(12/12) Junte-se a nós no DISCORD para conhecer outros usuários FamiStudio e compartilhar suas músicas com eles! Link na documentação
-WelcomeTitle=Welcome to FamiStudio! #TODO!
+WelcomeTitle=Bem-vindo(a) ao FamiStudio!
 
 [PropertyDialog]
 AcceptTooltip=Aceitar
@@ -1437,7 +1437,7 @@ VideoPreviewLabel=Pré-visualização do vídeo
 VideoPreviewTooltip=A pré-visualização do vídeo começara em breve, músicas com muitos canais podem demorar mais para começar. Esta pré-visualização não inclui áudio ou compressão. A taxa de quadros pode não ser precisa e a resolução é mais baixa do que a do vídeo real.
 
 [DropDown]
-SelectValueLabel=Select Value #TODO!
+SelectValueLabel=Selecione um Valor
 
 [MixerProperties]
 ; Labels
@@ -1461,15 +1461,15 @@ GlobalGridTooltip=O volume global (em dB) aplicado para todo áudio gerado. Quan
 ExpansionGridTooltip=O volume (em dB), a quantidade de agudo (em dB) e a frequência a partir da qual o agudo será reduzido (in Hz) para cada expansão.
 
 [FamiStudioWindow]
-EnterTextLabel=Enter Text #TODO!
-YesButton=Yes #TODO!
-NoButton=No #TODO!
-CancelButton=Cancel #TODO!
-OKButton=OK #TODO!
+EnterTextLabel=Digite texto
+YesButton=Sim
+NoButton=Não
+CancelButton=Cancelar
+OKButton=OK
 
 [CheckBoxList]
-SelectAllLabel=Select All #TODO!
-SelectNoneLabel=Select None #TODO!
+SelectAllLabel=Selecionar todos
+SelectNoneLabel=Selecionar nenhum
 
 [LogTextBox]
-CopyLogTextContext=Copy log text #TODO!
+CopyLogTextContext=Copy texto do log


### PR DESCRIPTION
Translated untranslated lines, fixed a spelling error and changed *all* references to "arpeggios" to instead be "arpejos", which is more proper. Yipee!