### PR TITLE
famistudio_music_pause no longer stops sampled sound effects

### DIFF
--- a/SoundEngine/famistudio_asm6.asm
+++ b/SoundEngine/famistudio_asm6.asm
@@ -1757,9 +1757,13 @@ famistudio_music_pause:
     beq @unpause
     
 @pause:
-
+.if FAMISTUDIO_CFG_DPCM_SUPPORT
+    lda famistudio_dpcm_effect
+    bne @no_stop_samples ; pausing music should not stop sampled sfx
+.endif
     jsr famistudio_sample_stop
-    
+
+@no_stop_samples:
     lda #0
     sta famistudio_env_value+FAMISTUDIO_CH0_ENVS+FAMISTUDIO_ENV_VOLUME_OFF
     sta famistudio_env_value+FAMISTUDIO_CH1_ENVS+FAMISTUDIO_ENV_VOLUME_OFF

--- a/SoundEngine/famistudio_ca65.s
+++ b/SoundEngine/famistudio_ca65.s
@@ -1780,6 +1780,7 @@ famistudio_music_pause:
     bne @no_stop_samples ; pausing music should not stop sampled sfx
 .endif
     jsr famistudio_sample_stop
+
 @no_stop_samples:
     lda #0
     sta famistudio_env_value+FAMISTUDIO_CH0_ENVS+FAMISTUDIO_ENV_VOLUME_OFF

--- a/SoundEngine/famistudio_ca65.s
+++ b/SoundEngine/famistudio_ca65.s
@@ -1775,9 +1775,12 @@ famistudio_music_pause:
     beq @unpause
     
 @pause:
-
+.if FAMISTUDIO_CFG_DPCM_SUPPORT
+    lda famistudio_dpcm_effect
+    bne @no_stop_samples ; pausing music should not stop sampled sfx
+.endif
     jsr famistudio_sample_stop
-    
+@no_stop_samples:
     lda #0
     sta famistudio_env_value+FAMISTUDIO_CH0_ENVS+FAMISTUDIO_ENV_VOLUME_OFF
     sta famistudio_env_value+FAMISTUDIO_CH1_ENVS+FAMISTUDIO_ENV_VOLUME_OFF

--- a/SoundEngine/famistudio_multi_ca65.s
+++ b/SoundEngine/famistudio_multi_ca65.s
@@ -1812,9 +1812,13 @@ famistudio_music_pause:
     ; [MULTI] END
     
 @pause:
-
+.if FAMISTUDIO_CFG_DPCM_SUPPORT
+    lda famistudio_dpcm_effect
+    bne @no_stop_samples ; pausing music should not stop sampled sfx
+.endif
     jsr famistudio_sample_stop
-    
+
+ @no_stop_samples:   
     lda #0
     sta famistudio_env_value+FAMISTUDIO_CH0_ENVS+FAMISTUDIO_ENV_VOLUME_OFF
     sta famistudio_env_value+FAMISTUDIO_CH1_ENVS+FAMISTUDIO_ENV_VOLUME_OFF


### PR DESCRIPTION
Originally, this subroutine's blanket call to `famistudio_sample_stop` would cause the channel to stop playing even if it was playing a sound effect instead of music; this request adds a brief check to `famistudio_dpcm_effect` before calling the function to skip it if a sound effect is playing in the channel.