### PR TITLE
Limited hardware sweep support for sound engine

### DIFF
--- a/SoundEngine/famistudio_asm6.asm
+++ b/SoundEngine/famistudio_asm6.asm
@@ -235,6 +235,17 @@ FAMISTUDIO_USE_ARPEGGIO          = 1
 ; Must be enabled if your project uses the "Phase Reset" effect.
 ; FAMISTUDIO_USE_PHASE_RESET = 1
 
+; Allows sound effects on the 2A03 pulse channels to use hardware sweeps.
+; Only makes sense if sound effects are enabled (FAMISTUDIO_CFG_SFX_SUPPORT),
+; and is primarily geared towards a single sfx stream (FAMISTUDIO_CFG_SFX_STREAMS).
+; Will disable smooth vibrato on those channels (FAMISTUDIO_CFG_SMOOTH_VIBRATO) to avoid sweep conflicts, 
+; although this may change in the future.
+; Also enables sound effect precedence (FAMISTUDIO_ALWAYS_PLAY_SFX) for similar reasons.
+; FAMISTUDIO_USE_HARDWARE_SWEEP  = 1
+
+; Prevents sound effects from being interrupted by music.
+; FAMISTUDIO_ALWAYS_PLAY_SFX   = 1
+
 ; Must be enabled if your project uses the FDS expansion and at least one instrument with FDS Auto-Mod enabled.
 ; FAMISTUDIO_USE_FDS_AUTOMOD  = 1
 
@@ -352,6 +363,10 @@ FAMISTUDIO_USE_ARPEGGIO          = 1
     FAMISTUDIO_CFG_SFX_STREAMS = 1
 .endif
 
+.ifndef FAMISTUDIO_ALWAYS_PLAY_SFX
+    FAMISTUDIO_ALWAYS_PLAY_SFX = 0
+.endif
+
 .ifndef FAMISTUDIO_CFG_C_BINDINGS
     FAMISTUDIO_CFG_C_BINDINGS = 0
 .endif
@@ -414,6 +429,10 @@ FAMISTUDIO_USE_ARPEGGIO          = 1
 
 .ifndef FAMISTUDIO_USE_PHASE_RESET
     FAMISTUDIO_USE_PHASE_RESET = 0
+.endif
+
+.ifndef FAMISTUDIO_USE_HARDWARE_SWEEP
+    FAMISTUDIO_USE_HARDWARE_SWEEP = 0
 .endif
 
 .ifndef FAMISTUDIO_USE_FDS_AUTOMOD
@@ -796,7 +815,11 @@ FAMISTUDIO_EPSM_PITCH_SHIFT = 3
 .endif
 
 .if FAMISTUDIO_CFG_SFX_SUPPORT
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
+    FAMISTUDIO_SFX_STRUCT_SIZE = 17
+.else
     FAMISTUDIO_SFX_STRUCT_SIZE = 15
+.endif
 
     FAMISTUDIO_SFX_CH0 = FAMISTUDIO_SFX_STRUCT_SIZE * 0
     FAMISTUDIO_SFX_CH1 = FAMISTUDIO_SFX_STRUCT_SIZE * 1
@@ -958,6 +981,10 @@ famistudio_dpcm_list_hi:          .dsb 1 ; TODO: Not needed if DPCM support is d
 famistudio_dpcm_effect:           .dsb 1 ; TODO: Not needed if DPCM support is disabled.
 famistudio_pulse1_prev:           .dsb 1
 famistudio_pulse2_prev:           .dsb 1
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
+famistudio_sweep1_prev:           .dsb 1
+famistudio_sweep2_prev:           .dsb 1
+.endif
 famistudio_song_speed:            .dsb 1
 
 .if FAMISTUDIO_EXP_MMC5
@@ -992,7 +1019,11 @@ famistudio_exp_instrument_hi:     .dsb 1
 
 .if FAMISTUDIO_CFG_SFX_SUPPORT
 
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
+famistudio_output_buf:     .dsb 13
+.else
 famistudio_output_buf:     .dsb 11
+.endif
 famistudio_sfx_addr_lo:    .dsb 1
 famistudio_sfx_addr_hi:    .dsb 1
 famistudio_sfx_base_addr:  .dsb (FAMISTUDIO_CFG_SFX_STREAMS * FAMISTUDIO_SFX_STRUCT_SIZE)
@@ -1254,6 +1285,10 @@ FAMISTUDIO_FDS_ENV_SPEED  = $408A
     FAMISTUDIO_ALIAS_TRI_HI     = famistudio_output_buf + 8
     FAMISTUDIO_ALIAS_NOISE_VOL  = famistudio_output_buf + 9
     FAMISTUDIO_ALIAS_NOISE_LO   = famistudio_output_buf + 10
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
+    FAMISTUDIO_ALIAS_PL1_SWEEP  = famistudio_output_buf + 11
+    FAMISTUDIO_ALIAS_PL2_SWEEP  = famistudio_output_buf + 12
+.endif
 .endif
 
 ;======================================================================================================================
@@ -1321,6 +1356,12 @@ famistudio_init:
     lda #$80 ; Previous pulse period MSB, to not write it when not changed
     sta famistudio_pulse1_prev
     sta famistudio_pulse2_prev
+
+    .if FAMISTUDIO_USE_HARDWARE_SWEEP
+        lda #$80 ; Previous hardware sweep values, to keep track of state transitions
+        sta famistudio_sweep1_prev
+        sta famistudio_sweep2_prev
+    .endif
 
     lda #$0f ; Enable channels, stop DMC
     sta FAMISTUDIO_APU_SND_CHN
@@ -4202,9 +4243,13 @@ famistudio_update:
 
 ;----------------------------------------------------------------------------------------------------------------------
 @update_sound:
-
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
+    famistudio_update_channel_sound 0, FAMISTUDIO_CH0_ENVS, famistudio_pulse1_prev, FAMISTUDIO_ALIAS_PL1_HI, FAMISTUDIO_ALIAS_PL1_LO, FAMISTUDIO_ALIAS_PL1_VOL, FAMISTUDIO_ALIAS_PL1_SWEEP
+    famistudio_update_channel_sound 1, FAMISTUDIO_CH1_ENVS, famistudio_pulse2_prev, FAMISTUDIO_ALIAS_PL2_HI, FAMISTUDIO_ALIAS_PL2_LO, FAMISTUDIO_ALIAS_PL2_VOL, FAMISTUDIO_ALIAS_PL2_SWEEP
+.else
     famistudio_update_channel_sound 0, FAMISTUDIO_CH0_ENVS, famistudio_pulse1_prev, FAMISTUDIO_ALIAS_PL1_HI, FAMISTUDIO_ALIAS_PL1_LO, FAMISTUDIO_ALIAS_PL1_VOL, FAMISTUDIO_APU_PL1_SWEEP
     famistudio_update_channel_sound 1, FAMISTUDIO_CH1_ENVS, famistudio_pulse2_prev, FAMISTUDIO_ALIAS_PL2_HI, FAMISTUDIO_ALIAS_PL2_LO, FAMISTUDIO_ALIAS_PL2_VOL, FAMISTUDIO_APU_PL2_SWEEP
+.endif
     famistudio_update_channel_sound 2, FAMISTUDIO_CH2_ENVS, 0, FAMISTUDIO_ALIAS_TRI_HI, FAMISTUDIO_ALIAS_TRI_LO, FAMISTUDIO_ALIAS_TRI_LINEAR, 0
     famistudio_update_channel_sound 3, FAMISTUDIO_CH3_ENVS, 0, FAMISTUDIO_ALIAS_NOISE_LO, 0, FAMISTUDIO_ALIAS_NOISE_VOL, 0
 
@@ -4316,6 +4361,11 @@ famistudio_update:
 ;----------------------------------------------------------------------------------------------------------------------
 .if FAMISTUDIO_CFG_SFX_SUPPORT
 
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
+    lda #$08 ; turn off sweeps (sfx can reenable them later)
+    sta famistudio_output_buf+11
+    sta famistudio_output_buf+12
+.endif
     ; Process all sound effect streams
     .if FAMISTUDIO_CFG_SFX_STREAMS > 0
     ldx #FAMISTUDIO_SFX_CH0
@@ -4334,37 +4384,98 @@ famistudio_update:
     jsr famistudio_sfx_update
     .endif
 
-    ; Send data from the output buffer to the APU
+; Send data from the output buffer to the APU
+    .if FAMISTUDIO_USE_HARDWARE_SWEEP
+        lda famistudio_output_buf      ; Pulse 1 volume
+        sta FAMISTUDIO_APU_PL1_VOL
+        lda famistudio_output_buf+11   ; Pulse 1 sweep
+        cmp #$7f                       ; special 'continue' value
+        beq @no_pulse1_upd             
+        cmp #$00                       ; a fresh sweep value should always write the full period
+        bmi @pulse1_period_no_cmp      ; active sweeps have their 7th bit set
+        lda famistudio_sweep1_prev
+        bmi @pulse1_period_no_cmp      ; always write the full pitch if coming from an active sweep
 
-    lda famistudio_output_buf      ; Pulse 1 volume
-    sta FAMISTUDIO_APU_PL1_VOL
-    lda famistudio_output_buf+1    ; Pulse 1 period LSB
-    sta FAMISTUDIO_APU_PL1_LO
-    lda famistudio_output_buf+2    ; Pulse 1 period MSB, only applied when changed
-
-    .if FAMISTUDIO_CFG_SMOOTH_VIBRATO
-        famistudio_smooth_vibrato famistudio_output_buf+1, famistudio_pulse1_prev, FAMISTUDIO_APU_PL1_HI, FAMISTUDIO_APU_PL1_LO, FAMISTUDIO_APU_PL1_SWEEP
-    .else
+        lda famistudio_output_buf+1    ; Pulse 1 period LSB
+        sta FAMISTUDIO_APU_PL1_LO
+        lda famistudio_output_buf+2    ; Pulse 1 period MSB, only applied when changed
         cmp famistudio_pulse1_prev
-        beq @no_pulse1_upd
+        beq @sweep1_update
         sta famistudio_pulse1_prev
         sta FAMISTUDIO_APU_PL1_HI
-    .endif        
+        jmp @sweep1_update
+    @pulse1_period_no_cmp:
+        lda famistudio_output_buf+1    ; Pulse 1 period LSB
+        sta FAMISTUDIO_APU_PL1_LO
+        lda famistudio_output_buf+2    ; Pulse 1 period MSB
+        sta famistudio_pulse1_prev
+        sta FAMISTUDIO_APU_PL1_HI
+    @sweep1_update:
+        lda famistudio_output_buf+11   ; Pulse 1 sweep
+        sta famistudio_sweep1_prev
+        sta FAMISTUDIO_APU_PL1_SWEEP
 
-@no_pulse1_upd:
-    lda famistudio_output_buf+3    ; Pulse 2 volume
-    sta FAMISTUDIO_APU_PL2_VOL
-    lda famistudio_output_buf+4    ; Pulse 2 period LSB
-    sta FAMISTUDIO_APU_PL2_LO
-    lda famistudio_output_buf+5    ; Pulse 2 period MSB, only applied when changed
+    @no_pulse1_upd:
+        lda famistudio_output_buf+3    ; Pulse 2 volume
+        sta FAMISTUDIO_APU_PL2_VOL
+        lda famistudio_output_buf+12   ; Pulse 2 sweep
+        cmp #$7f                       ; special 'continue' value
+        beq @no_pulse2_upd             
+        cmp #$00                       ; a fresh sweep value should always write the full period
+        bmi @pulse2_period_no_cmp      ; active sweeps have their 7th bit set
+        lda famistudio_sweep2_prev
+        bmi @pulse2_period_no_cmp      ; always write the full pitch if coming from an active sweep
 
-    .if FAMISTUDIO_CFG_SMOOTH_VIBRATO
-        famistudio_smooth_vibrato famistudio_output_buf+4, famistudio_pulse2_prev, FAMISTUDIO_APU_PL2_HI, FAMISTUDIO_APU_PL2_LO, FAMISTUDIO_APU_PL2_SWEEP
-    .else
+        lda famistudio_output_buf+4    ; Pulse 2 period LSB
+        sta FAMISTUDIO_APU_PL2_LO
+        lda famistudio_output_buf+5    ; Pulse 2 period MSB, only applied when changed
         cmp famistudio_pulse2_prev
-        beq @no_pulse2_upd
+        beq @sweep2_update
         sta famistudio_pulse2_prev
         sta FAMISTUDIO_APU_PL2_HI
+        jmp @sweep2_update
+    @pulse2_period_no_cmp:
+        lda famistudio_output_buf+4    ; Pulse 2 period LSB
+        sta FAMISTUDIO_APU_PL2_LO
+        lda famistudio_output_buf+5    ; Pulse 2 period MSB
+        sta famistudio_pulse2_prev
+        sta FAMISTUDIO_APU_PL2_HI
+    @sweep2_update:
+        lda famistudio_output_buf+12   ; Pulse 1 sweep
+        sta famistudio_sweep2_prev
+        sta FAMISTUDIO_APU_PL2_SWEEP
+
+    .else
+        lda famistudio_output_buf      ; Pulse 1 volume
+        sta FAMISTUDIO_APU_PL1_VOL
+        lda famistudio_output_buf+1    ; Pulse 1 period LSB
+        sta FAMISTUDIO_APU_PL1_LO
+        lda famistudio_output_buf+2    ; Pulse 1 period MSB, only applied when changed
+
+        .if FAMISTUDIO_CFG_SMOOTH_VIBRATO
+            famistudio_smooth_vibrato famistudio_output_buf+1, famistudio_pulse1_prev, FAMISTUDIO_APU_PL1_HI, FAMISTUDIO_APU_PL1_LO, FAMISTUDIO_APU_PL1_SWEEP
+        .else
+            cmp famistudio_pulse1_prev
+            beq @no_pulse1_upd
+            sta famistudio_pulse1_prev
+            sta FAMISTUDIO_APU_PL1_HI
+        .endif        
+
+    @no_pulse1_upd:
+        lda famistudio_output_buf+3    ; Pulse 2 volume
+        sta FAMISTUDIO_APU_PL2_VOL
+        lda famistudio_output_buf+4    ; Pulse 2 period LSB
+        sta FAMISTUDIO_APU_PL2_LO
+        lda famistudio_output_buf+5    ; Pulse 2 period MSB, only applied when changed
+
+        .if FAMISTUDIO_CFG_SMOOTH_VIBRATO
+            famistudio_smooth_vibrato famistudio_output_buf+4, famistudio_pulse2_prev, FAMISTUDIO_APU_PL2_HI, FAMISTUDIO_APU_PL2_LO, FAMISTUDIO_APU_PL2_SWEEP
+        .else
+            cmp famistudio_pulse2_prev
+            beq @no_pulse2_upd
+            sta famistudio_pulse2_prev
+            sta FAMISTUDIO_APU_PL2_HI
+        .endif
     .endif
 
 @no_pulse2_upd:
@@ -6596,6 +6707,20 @@ famistudio_sfx_update:
 
     lda famistudio_sfx_repeat,x ; Check if repeat counter is not zero
     beq @no_repeat
+    .if FAMISTUDIO_USE_HARDWARE_SWEEP
+        lda famistudio_sfx_buffer+11, x ; no need to handle sweeps if no sweeps
+        cmp #$7f
+        bcc @no_pul1_sweep_continue
+        lda #$7f ; special 'continue' flag for the sweep state
+        sta famistudio_sfx_buffer+11, x
+    @no_pul1_sweep_continue:
+        lda famistudio_sfx_buffer+12, x
+        cmp #$7f
+        bcc @no_pul2_sweep_continue
+        lda #$7f
+        sta famistudio_sfx_buffer+12, x ; sweep writes should not repeat
+    @no_pul2_sweep_continue:
+    .endif
     dec famistudio_sfx_repeat,x ; Decrement and return
     bne @update_buf ; Just mix with output buffer
 
@@ -6648,13 +6773,29 @@ famistudio_sfx_update:
     sta famistudio_sfx_ptr_hi,x ; Mark channel as inactive
 
 @update_buf:
-    lda famistudio_output_buf ; Compare effect output buffer with main output buffer
-    and #$0f ; If volume of pulse 1 of effect is higher than that of the main buffer, overwrite the main buffer value with the new one
-    sta tmp 
+    .if FAMISTUDIO_USE_HARDWARE_SWEEP
+        lda famistudio_sfx_buffer+11,x ; A sweeping effect should always play
+        cmp #$7f
+        bcs @write_pulse1
+    .endif
+    .if FAMISTUDIO_ALWAYS_PLAY_SFX || FAMISTUDIO_USE_HARDWARE_SWEEP
+        lda #$01 ; Check if the effect volume is active
+    .else
+        lda famistudio_output_buf ; Compare effect output buffer with main output buffer
+        and #$0f ; If volume of pulse 1 is higher than that of the main buffer, overwrite the main buffer value with the new one
+    .endif
+    sta @tmp ; If volume of pulse 1 of effect is high enough, overwrite the main buffer value with the new one
     lda famistudio_sfx_buffer+0,x
     and #$0f
-    cmp tmp
+    cmp @tmp
     bcc @no_pulse1
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
+    lda famistudio_sfx_buffer+11,x
+.endif
+@write_pulse1:
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
+    sta famistudio_output_buf+11
+.endif
     lda famistudio_sfx_buffer+0,x
     sta famistudio_output_buf+0
     lda famistudio_sfx_buffer+1,x
@@ -6663,13 +6804,29 @@ famistudio_sfx_update:
     sta famistudio_output_buf+2
 
 @no_pulse1:
-    lda famistudio_output_buf+3
-    and #$0f
-    sta tmp
+    .if FAMISTUDIO_USE_HARDWARE_SWEEP
+        lda famistudio_sfx_buffer+12,x
+        cmp #$7f
+        bcs @write_pulse2
+    .endif
+    .if FAMISTUDIO_ALWAYS_PLAY_SFX || FAMISTUDIO_USE_HARDWARE_SWEEP
+        lda #$01
+    .else
+        lda famistudio_output_buf+3 ; Compare effect output buffer with main output buffer
+        and #$0f
+    .endif
+    sta @tmp
     lda famistudio_sfx_buffer+3,x
     and #$0f
-    cmp tmp
+    cmp @tmp
     bcc @no_pulse2
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
+    lda famistudio_sfx_buffer+12,x
+.endif
+@write_pulse2:
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
+    sta famistudio_output_buf+12
+.endif
     lda famistudio_sfx_buffer+3,x
     sta famistudio_output_buf+3
     lda famistudio_sfx_buffer+4,x

--- a/SoundEngine/famistudio_ca65.s
+++ b/SoundEngine/famistudio_ca65.s
@@ -6834,9 +6834,13 @@ famistudio_sfx_update:
     and #$0f
     cmp @tmp
     bcc @no_pulse1
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
     lda famistudio_sfx_buffer+11,x
+.endif
 @write_pulse1:
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
     sta famistudio_output_buf+11
+.endif
     lda famistudio_sfx_buffer+0,x
     sta famistudio_output_buf+0
     lda famistudio_sfx_buffer+1,x
@@ -6861,9 +6865,13 @@ famistudio_sfx_update:
     and #$0f
     cmp @tmp
     bcc @no_pulse2
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
     lda famistudio_sfx_buffer+12,x
+.endif
 @write_pulse2:
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
     sta famistudio_output_buf+12
+.endif
     lda famistudio_sfx_buffer+3,x
     sta famistudio_output_buf+3
     lda famistudio_sfx_buffer+4,x

--- a/SoundEngine/famistudio_ca65.s
+++ b/SoundEngine/famistudio_ca65.s
@@ -236,6 +236,17 @@ FAMISTUDIO_USE_ARPEGGIO          = 1
 ; Must be enabled if your project uses the "Phase Reset" effect.
 ; FAMISTUDIO_USE_PHASE_RESET = 1
 
+; Allows sound effects on the 2A03 pulse channels to use hardware sweeps.
+; Only makes sense if sound effects are enabled (FAMISTUDIO_CFG_SFX_SUPPORT),
+; and is primarily geared towards a single sfx stream (FAMISTUDIO_CFG_SFX_STREAMS).
+; Will disable smooth vibrato on those channels (FAMISTUDIO_CFG_SMOOTH_VIBRATO) to avoid sweep conflicts, 
+; although this may change in the future.
+; Also enables sound effect precedence (FAMISTUDIO_ALWAYS_PLAY_SFX) for similar reasons.
+; FAMISTUDIO_USE_HARDWARE_SWEEP  = 1
+
+; Prevents sound effects from being interrupted by music.
+; FAMISTUDIO_ALWAYS_PLAY_SFX   = 1
+
 ; Must be enabled if your project uses the FDS expansion and at least one instrument with FDS Auto-Mod enabled.
 ; FAMISTUDIO_USE_FDS_AUTOMOD  = 1
 
@@ -353,6 +364,10 @@ FAMISTUDIO_USE_ARPEGGIO          = 1
     FAMISTUDIO_CFG_SFX_STREAMS = 1
 .endif
 
+.ifndef FAMISTUDIO_ALWAYS_PLAY_SFX
+    FAMISTUDIO_ALWAYS_PLAY_SFX = 0
+.endif
+
 .ifndef FAMISTUDIO_CFG_C_BINDINGS
     FAMISTUDIO_CFG_C_BINDINGS = 0
 .endif
@@ -415,6 +430,10 @@ FAMISTUDIO_USE_ARPEGGIO          = 1
 
 .ifndef FAMISTUDIO_USE_PHASE_RESET
     FAMISTUDIO_USE_PHASE_RESET = 0
+.endif
+
+.ifndef FAMISTUDIO_USE_HARDWARE_SWEEP
+    FAMISTUDIO_USE_HARDWARE_SWEEP = 0
 .endif
 
 .ifndef FAMISTUDIO_USE_FDS_AUTOMOD
@@ -798,7 +817,11 @@ FAMISTUDIO_EPSM_PITCH_SHIFT = 3
 .endif
 
 .if FAMISTUDIO_CFG_SFX_SUPPORT
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
+    FAMISTUDIO_SFX_STRUCT_SIZE = 17
+.else
     FAMISTUDIO_SFX_STRUCT_SIZE = 15
+.endif
 
     FAMISTUDIO_SFX_CH0 = FAMISTUDIO_SFX_STRUCT_SIZE * 0
     FAMISTUDIO_SFX_CH1 = FAMISTUDIO_SFX_STRUCT_SIZE * 1
@@ -960,6 +983,10 @@ famistudio_dpcm_list_hi:          .res 1 ; TODO: Not needed if DPCM support is d
 famistudio_dpcm_effect:           .res 1 ; TODO: Not needed if DPCM support is disabled.
 famistudio_pulse1_prev:           .res 1
 famistudio_pulse2_prev:           .res 1
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
+famistudio_sweep1_prev:           .res 1
+famistudio_sweep2_prev:           .res 1
+.endif
 famistudio_song_speed:            .res 1
 
 .if FAMISTUDIO_EXP_MMC5
@@ -994,7 +1021,11 @@ famistudio_exp_instrument_hi:     .res 1
 
 .if FAMISTUDIO_CFG_SFX_SUPPORT
 
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
+famistudio_output_buf:     .res 13
+.else
 famistudio_output_buf:     .res 11
+.endif
 famistudio_sfx_addr_lo:    .res 1
 famistudio_sfx_addr_hi:    .res 1
 famistudio_sfx_base_addr:  .res (FAMISTUDIO_CFG_SFX_STREAMS * FAMISTUDIO_SFX_STRUCT_SIZE)
@@ -1272,6 +1303,10 @@ FAMISTUDIO_FDS_ENV_SPEED  = $408A
     FAMISTUDIO_ALIAS_TRI_HI     = famistudio_output_buf + 8
     FAMISTUDIO_ALIAS_NOISE_VOL  = famistudio_output_buf + 9
     FAMISTUDIO_ALIAS_NOISE_LO   = famistudio_output_buf + 10
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
+    FAMISTUDIO_ALIAS_PL1_SWEEP  = famistudio_output_buf + 11
+    FAMISTUDIO_ALIAS_PL2_SWEEP  = famistudio_output_buf + 12
+.endif
 .endif
 
 ;======================================================================================================================
@@ -1339,6 +1374,12 @@ famistudio_init:
     lda #$80 ; Previous pulse period MSB, to not write it when not changed
     sta famistudio_pulse1_prev
     sta famistudio_pulse2_prev
+
+    .if FAMISTUDIO_USE_HARDWARE_SWEEP
+        lda #$80 ; Previous hardware sweep values, to keep track of state transitions
+        sta famistudio_sweep1_prev
+        sta famistudio_sweep2_prev
+    .endif
 
     lda #$0f ; Enable channels, stop DMC
     sta FAMISTUDIO_APU_SND_CHN
@@ -4248,9 +4289,13 @@ famistudio_update:
 
 ;----------------------------------------------------------------------------------------------------------------------
 @update_sound:
-
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
+    famistudio_update_channel_sound 0, FAMISTUDIO_CH0_ENVS, famistudio_pulse1_prev, FAMISTUDIO_ALIAS_PL1_HI, FAMISTUDIO_ALIAS_PL1_LO, FAMISTUDIO_ALIAS_PL1_VOL, FAMISTUDIO_ALIAS_PL1_SWEEP
+    famistudio_update_channel_sound 1, FAMISTUDIO_CH1_ENVS, famistudio_pulse2_prev, FAMISTUDIO_ALIAS_PL2_HI, FAMISTUDIO_ALIAS_PL2_LO, FAMISTUDIO_ALIAS_PL2_VOL, FAMISTUDIO_ALIAS_PL2_SWEEP
+.else
     famistudio_update_channel_sound 0, FAMISTUDIO_CH0_ENVS, famistudio_pulse1_prev, FAMISTUDIO_ALIAS_PL1_HI, FAMISTUDIO_ALIAS_PL1_LO, FAMISTUDIO_ALIAS_PL1_VOL, FAMISTUDIO_APU_PL1_SWEEP
     famistudio_update_channel_sound 1, FAMISTUDIO_CH1_ENVS, famistudio_pulse2_prev, FAMISTUDIO_ALIAS_PL2_HI, FAMISTUDIO_ALIAS_PL2_LO, FAMISTUDIO_ALIAS_PL2_VOL, FAMISTUDIO_APU_PL2_SWEEP
+.endif
     famistudio_update_channel_sound 2, FAMISTUDIO_CH2_ENVS, , FAMISTUDIO_ALIAS_TRI_HI, FAMISTUDIO_ALIAS_TRI_LO, FAMISTUDIO_ALIAS_TRI_LINEAR
     famistudio_update_channel_sound 3, FAMISTUDIO_CH3_ENVS, , FAMISTUDIO_ALIAS_NOISE_LO, , FAMISTUDIO_ALIAS_NOISE_VOL
 
@@ -4362,6 +4407,11 @@ famistudio_update:
 ;----------------------------------------------------------------------------------------------------------------------
 .if FAMISTUDIO_CFG_SFX_SUPPORT
 
+.if FAMISTUDIO_USE_HARDWARE_SWEEP
+    lda #$08 ; turn off sweeps (sfx can reenable them later)
+    sta famistudio_output_buf+11
+    sta famistudio_output_buf+12
+.endif
     ; Process all sound effect streams
     .if FAMISTUDIO_CFG_SFX_STREAMS > 0
     ldx #FAMISTUDIO_SFX_CH0
@@ -4381,38 +4431,98 @@ famistudio_update:
     .endif
 
     ; Send data from the output buffer to the APU
-
-    lda famistudio_output_buf      ; Pulse 1 volume
-    sta FAMISTUDIO_APU_PL1_VOL
-    lda famistudio_output_buf+1    ; Pulse 1 period LSB
-    sta FAMISTUDIO_APU_PL1_LO
-    lda famistudio_output_buf+2    ; Pulse 1 period MSB, only applied when changed
-
-    .if FAMISTUDIO_CFG_SMOOTH_VIBRATO
-        famistudio_smooth_vibrato famistudio_output_buf+1, famistudio_pulse1_prev, FAMISTUDIO_APU_PL1_HI, FAMISTUDIO_APU_PL1_LO, FAMISTUDIO_APU_PL1_SWEEP
-    .else
+    .if FAMISTUDIO_USE_HARDWARE_SWEEP
+        lda famistudio_output_buf      ; Pulse 1 volume
+        sta FAMISTUDIO_APU_PL1_VOL
+        lda famistudio_output_buf+11   ; Pulse 1 sweep
+        cmp #$7f                       ; special 'continue' value
+        beq @no_pulse1_upd             
+        cmp #$00                       ; a fresh sweep value should always write the full period
+        bmi @pulse1_period_no_cmp      ; active sweeps have their 7th bit set
+        lda famistudio_sweep1_prev
+        bmi @pulse1_period_no_cmp      ; always write the full pitch if coming from an active sweep
+    
+        lda famistudio_output_buf+1    ; Pulse 1 period LSB
+        sta FAMISTUDIO_APU_PL1_LO
+        lda famistudio_output_buf+2    ; Pulse 1 period MSB, only applied when changed
         cmp famistudio_pulse1_prev
-        beq @no_pulse1_upd
+        beq @sweep1_update
         sta famistudio_pulse1_prev
         sta FAMISTUDIO_APU_PL1_HI
-    .endif        
+        jmp @sweep1_update
+    @pulse1_period_no_cmp:
+        lda famistudio_output_buf+1    ; Pulse 1 period LSB
+        sta FAMISTUDIO_APU_PL1_LO
+        lda famistudio_output_buf+2    ; Pulse 1 period MSB
+        sta famistudio_pulse1_prev
+        sta FAMISTUDIO_APU_PL1_HI
+    @sweep1_update:
+        lda famistudio_output_buf+11   ; Pulse 1 sweep
+        sta famistudio_sweep1_prev
+        sta FAMISTUDIO_APU_PL1_SWEEP
 
-@no_pulse1_upd:
-    lda famistudio_output_buf+3    ; Pulse 2 volume
-    sta FAMISTUDIO_APU_PL2_VOL
-    lda famistudio_output_buf+4    ; Pulse 2 period LSB
-    sta FAMISTUDIO_APU_PL2_LO
-    lda famistudio_output_buf+5    ; Pulse 2 period MSB, only applied when changed
-
-    .if FAMISTUDIO_CFG_SMOOTH_VIBRATO
-        famistudio_smooth_vibrato famistudio_output_buf+4, famistudio_pulse2_prev, FAMISTUDIO_APU_PL2_HI, FAMISTUDIO_APU_PL2_LO, FAMISTUDIO_APU_PL2_SWEEP
-    .else
+    @no_pulse1_upd:
+        lda famistudio_output_buf+3    ; Pulse 2 volume
+        sta FAMISTUDIO_APU_PL2_VOL
+        lda famistudio_output_buf+12   ; Pulse 2 sweep
+        cmp #$7f                       ; special 'continue' value
+        beq @no_pulse2_upd             
+        cmp #$00                       ; a fresh sweep value should always write the full period
+        bmi @pulse2_period_no_cmp      ; active sweeps have their 7th bit set
+        lda famistudio_sweep2_prev
+        bmi @pulse2_period_no_cmp      ; always write the full pitch if coming from an active sweep
+    
+        lda famistudio_output_buf+4    ; Pulse 2 period LSB
+        sta FAMISTUDIO_APU_PL2_LO
+        lda famistudio_output_buf+5    ; Pulse 2 period MSB, only applied when changed
         cmp famistudio_pulse2_prev
-        beq @no_pulse2_upd
+        beq @sweep2_update
         sta famistudio_pulse2_prev
         sta FAMISTUDIO_APU_PL2_HI
-    .endif
+        jmp @sweep2_update
+    @pulse2_period_no_cmp:
+        lda famistudio_output_buf+4    ; Pulse 2 period LSB
+        sta FAMISTUDIO_APU_PL2_LO
+        lda famistudio_output_buf+5    ; Pulse 2 period MSB
+        sta famistudio_pulse2_prev
+        sta FAMISTUDIO_APU_PL2_HI
+    @sweep2_update:
+        lda famistudio_output_buf+12   ; Pulse 1 sweep
+        sta famistudio_sweep2_prev
+        sta FAMISTUDIO_APU_PL2_SWEEP
 
+    .else
+        lda famistudio_output_buf      ; Pulse 1 volume
+        sta FAMISTUDIO_APU_PL1_VOL
+        lda famistudio_output_buf+1    ; Pulse 1 period LSB
+        sta FAMISTUDIO_APU_PL1_LO
+        lda famistudio_output_buf+2    ; Pulse 1 period MSB, only applied when changed
+
+        .if FAMISTUDIO_CFG_SMOOTH_VIBRATO
+            famistudio_smooth_vibrato famistudio_output_buf+1, famistudio_pulse1_prev, FAMISTUDIO_APU_PL1_HI, FAMISTUDIO_APU_PL1_LO, FAMISTUDIO_APU_PL1_SWEEP
+        .else
+            cmp famistudio_pulse1_prev
+            beq @no_pulse1_upd
+            sta famistudio_pulse1_prev
+            sta FAMISTUDIO_APU_PL1_HI
+        .endif        
+
+    @no_pulse1_upd:
+        lda famistudio_output_buf+3    ; Pulse 2 volume
+        sta FAMISTUDIO_APU_PL2_VOL
+        lda famistudio_output_buf+4    ; Pulse 2 period LSB
+        sta FAMISTUDIO_APU_PL2_LO
+        lda famistudio_output_buf+5    ; Pulse 2 period MSB, only applied when changed
+
+        .if FAMISTUDIO_CFG_SMOOTH_VIBRATO
+            famistudio_smooth_vibrato famistudio_output_buf+4, famistudio_pulse2_prev, FAMISTUDIO_APU_PL2_HI, FAMISTUDIO_APU_PL2_LO, FAMISTUDIO_APU_PL2_SWEEP
+        .else
+            cmp famistudio_pulse2_prev
+            beq @no_pulse2_upd
+            sta famistudio_pulse2_prev
+            sta FAMISTUDIO_APU_PL2_HI
+        .endif
+    .endif
 @no_pulse2_upd:
     lda famistudio_output_buf+6    ; Triangle volume (plays or not)
     sta FAMISTUDIO_APU_TRI_LINEAR
@@ -6642,6 +6752,20 @@ famistudio_sfx_update:
 
     lda famistudio_sfx_repeat,x ; Check if repeat counter is not zero
     beq @no_repeat
+    .if FAMISTUDIO_USE_HARDWARE_SWEEP
+        lda famistudio_sfx_buffer+11, x ; no need to handle sweeps if no sweeps
+        cmp #$7f
+        bcc @no_pul1_sweep_continue
+        lda #$7f ; special 'continue' flag for the sweep state
+        sta famistudio_sfx_buffer+11, x
+    @no_pul1_sweep_continue:
+        lda famistudio_sfx_buffer+12, x
+        cmp #$7f
+        bcc @no_pul2_sweep_continue
+        lda #$7f
+        sta famistudio_sfx_buffer+12, x ; sweep writes should not repeat
+    @no_pul2_sweep_continue:
+    .endif
     dec famistudio_sfx_repeat,x ; Decrement and return
     bne @update_buf ; Just mix with output buffer
 
@@ -6694,13 +6818,25 @@ famistudio_sfx_update:
     sta famistudio_sfx_ptr_hi,x ; Mark channel as inactive
 
 @update_buf:
-    lda famistudio_output_buf ; Compare effect output buffer with main output buffer
-    and #$0f ; If volume of pulse 1 of effect is higher than that of the main buffer, overwrite the main buffer value with the new one
-    sta @tmp 
+    .if FAMISTUDIO_USE_HARDWARE_SWEEP
+        lda famistudio_sfx_buffer+11,x ; A sweeping effect should always play
+        cmp #$7f
+        bcs @write_pulse1
+    .endif
+    .if FAMISTUDIO_ALWAYS_PLAY_SFX || FAMISTUDIO_USE_HARDWARE_SWEEP
+        lda #$01 ; Check if the effect volume is active
+    .else
+        lda famistudio_output_buf ; Compare effect output buffer with main output buffer
+        and #$0f ; If volume of pulse 1 is higher than that of the main buffer, overwrite the main buffer value with the new one
+    .endif
+    sta @tmp ; If volume of pulse 1 of effect is high enough, overwrite the main buffer value with the new one
     lda famistudio_sfx_buffer+0,x
     and #$0f
     cmp @tmp
     bcc @no_pulse1
+    lda famistudio_sfx_buffer+11,x
+@write_pulse1:
+    sta famistudio_output_buf+11
     lda famistudio_sfx_buffer+0,x
     sta famistudio_output_buf+0
     lda famistudio_sfx_buffer+1,x
@@ -6709,19 +6845,31 @@ famistudio_sfx_update:
     sta famistudio_output_buf+2
 
 @no_pulse1:
-    lda famistudio_output_buf+3
-    and #$0f
+    .if FAMISTUDIO_USE_HARDWARE_SWEEP
+        lda famistudio_sfx_buffer+12,x
+        cmp #$7f
+        bcs @write_pulse2
+    .endif
+    .if FAMISTUDIO_ALWAYS_PLAY_SFX || FAMISTUDIO_USE_HARDWARE_SWEEP
+        lda #$01
+    .else
+        lda famistudio_output_buf+3 ; Compare effect output buffer with main output buffer
+        and #$0f
+    .endif
     sta @tmp
     lda famistudio_sfx_buffer+3,x
     and #$0f
     cmp @tmp
     bcc @no_pulse2
+    lda famistudio_sfx_buffer+12,x
+@write_pulse2:
+    sta famistudio_output_buf+12
     lda famistudio_sfx_buffer+3,x
     sta famistudio_output_buf+3
     lda famistudio_sfx_buffer+4,x
     sta famistudio_output_buf+4
     lda famistudio_sfx_buffer+5,x
-    sta famistudio_output_buf+5
+    sta famistudio_output_buf+5    
 
 @no_pulse2:
     lda famistudio_sfx_buffer+6,x ; Overwrite triangle of main output buffer if it is active


### PR DESCRIPTION
This is a proposal for handling hardware sweeps in a sound effect-exclusive context within the sound engine with a new configuration flag: `FAMISTUDIO_USE_HARDWARE_SWEEP`. If enabled, sound effects can now include `$8b` and `$8c` opcodes to set Pulse 1 and Pulse 2's respective sweep registers on a given frame, and the output and effect buffers receive 2 new bytes to store these values. Because the sweep register shouldn't be written every frame (and since the period registers shouldn't be written to while the sweep is active), the code now includes additional checks to only write to these registers as necessary, namely by storing the previous value written to each sweep register and reserving the redundant value `#$7f` as a 'continue' flag that skips updating the period registers that frame.

To prevent the music from cutting out a swept sound effect early, another new configuration flag has been added in the form of `FAMISTUDIO_ALWAYS_PLAY_SFX`, which alters the volume check performed during `@update_buf` so that sound effects will always take precedence over music (or sound effects from a 'lower' stream, due to the nature of the new check). Although this was originally geared specifically towards hardware sweeps, it may also be useful for developers looking to mimic how most NES-era sound engines handled their sound effects.

The attached file features converted sound effects from Akumajou Densetsu, which provide a useful base for testing sweeps.

[Aku_SFX_New.txt](https://github.com/user-attachments/files/18241322/Aku_SFX_New.txt)
