### PR TITLE
More options for sound engine control

### DIFF
--- a/SoundEngine/famistudio_asm6.asm
+++ b/SoundEngine/famistudio_asm6.asm
@@ -6654,6 +6654,14 @@ famistudio_sfx_stop_all:
     ldx #FAMISTUDIO_SFX_CH3
     jsr famistudio_sfx_clear_channel
     .endif
+    .if FAMISTUDIO_CFG_DPCM_SUPPORT
+    lda famistudio_dpcm_effect ; Check if a sampled sfx is playing
+    beq @no_sample_sfx
+    lda #%00001111 ; Stop DPCM
+    sta FAMISTUDIO_APU_SND_CHN
+    rts
+    @no_sample_sfx:
+    .endif
     rts
 
 ;======================================================================================================================

--- a/SoundEngine/famistudio_asm6.asm
+++ b/SoundEngine/famistudio_asm6.asm
@@ -35,6 +35,7 @@
 ;   - famistudio_sfx_init        : Initialize SFX engine with SFX data.
 ;   - famistudio_sfx_play        : Play a SFX.
 ;   - famistudio_sfx_sample_play : Play a DPCM SFX.
+;   - famistudio_sfx_stop_all    : Stop currently playing SFX.
 ;   - famistudio_update          : Updates the music/SFX engine, call once per frame, ideally from NMI.
 ;
 ; You can check the demo ROM to see how they are used or check out the online documentation for more info.
@@ -6578,6 +6579,27 @@ famistudio_sfx_play:
     lda (effect_data_ptr),y
     sta famistudio_sfx_ptr_hi,x ; This write enables the effect
 
+    rts
+
+famistudio_sfx_stop_all:
+
+    ; Stop all sound effect streams
+    .if FAMISTUDIO_CFG_SFX_STREAMS > 0
+    ldx #FAMISTUDIO_SFX_CH0
+    jsr famistudio_sfx_clear_channel
+    .endif
+    .if FAMISTUDIO_CFG_SFX_STREAMS > 1
+    ldx #FAMISTUDIO_SFX_CH1
+    jsr famistudio_sfx_clear_channel
+    .endif
+    .if FAMISTUDIO_CFG_SFX_STREAMS > 2
+    ldx #FAMISTUDIO_SFX_CH2
+    jsr famistudio_sfx_clear_channel
+    .endif
+    .if FAMISTUDIO_CFG_SFX_STREAMS > 3
+    ldx #FAMISTUDIO_SFX_CH3
+    jsr famistudio_sfx_clear_channel
+    .endif
     rts
 
 ;======================================================================================================================

--- a/SoundEngine/famistudio_ca65.s
+++ b/SoundEngine/famistudio_ca65.s
@@ -6721,7 +6721,7 @@ famistudio_sfx_stop_all:
     lda #%00001111 ; Stop DPCM
     sta FAMISTUDIO_APU_SND_CHN
     rts
-    @no_sample_sfx
+    @no_sample_sfx:
     .endif
     rts 
 

--- a/SoundEngine/famistudio_ca65.s
+++ b/SoundEngine/famistudio_ca65.s
@@ -6846,6 +6846,7 @@ famistudio_sfx_update:
 
 .endif
 
+.if FAMISTUDIO_CFG_MUTING_SUPPORT
 ;======================================================================================================================
 ; FAMISTUDIO_SET_MUTING (public)
 ;
@@ -6865,6 +6866,7 @@ famistudio_sfx_update:
 famistudio_set_muting:
     sta famistudio_mute_mask
     rts
+.endif
 
 ; Dummy envelope used to initialize all channels with silence
 famistudio_dummy_envelope:

--- a/SoundEngine/famistudio_ca65.s
+++ b/SoundEngine/famistudio_ca65.s
@@ -35,6 +35,7 @@
 ;   - famistudio_sfx_init        : Initialize SFX engine with SFX data.
 ;   - famistudio_sfx_play        : Play a SFX.
 ;   - famistudio_sfx_sample_play : Play a DPCM SFX.
+;   - famistudio_sfx_stop_all    : Stop currently playing SFX.
 ;   - famistudio_update          : Updates the music/SFX engine, call once per frame, ideally from NMI.
 ;
 ; You can check the demo ROM to see how they are used or check out the online documentation for more info.
@@ -1048,6 +1049,7 @@ famistudio_ptr1_hi = famistudio_ptr1+1
 .endif
 .export famistudio_sfx_init
 .export famistudio_sfx_play
+.export famistudio_sfx_stop_all
 .exportzp FAMISTUDIO_SFX_CH0
 .exportzp FAMISTUDIO_SFX_CH1
 .exportzp FAMISTUDIO_SFX_CH2
@@ -6627,6 +6629,36 @@ famistudio_sfx_play:
     rts
 
 ;======================================================================================================================
+; FAMISTUDIO_SFX_STOP_ALL (public)
+;
+; Stops all playing sound effects.
+;
+; [in] no input params.
+;
+;======================================================================================================================
+
+famistudio_sfx_stop_all:
+
+    ; Stop all sound effect streams
+    .if FAMISTUDIO_CFG_SFX_STREAMS > 0
+    ldx #FAMISTUDIO_SFX_CH0
+    jsr famistudio_sfx_clear_channel
+    .endif
+    .if FAMISTUDIO_CFG_SFX_STREAMS > 1
+    ldx #FAMISTUDIO_SFX_CH1
+    jsr famistudio_sfx_clear_channel
+    .endif
+    .if FAMISTUDIO_CFG_SFX_STREAMS > 2
+    ldx #FAMISTUDIO_SFX_CH2
+    jsr famistudio_sfx_clear_channel
+    .endif
+    .if FAMISTUDIO_CFG_SFX_STREAMS > 3
+    ldx #FAMISTUDIO_SFX_CH3
+    jsr famistudio_sfx_clear_channel
+    .endif
+    rts 
+
+;======================================================================================================================
 ; FAMISTUDIO_SFX_UPDATE (internal)
 ;
 ; Updates a single sound effect stream.
@@ -7489,6 +7521,9 @@ _famistudio_sfx_play:
 
 ; A = sample_index; So we can safely re-export the symbol
 .export _famistudio_sfx_sample_play=famistudio_sfx_sample_play
+
+; No parameters so its safe to re-export
+.export _famistudio_sfx_stop_all=famistudio_sfx_stop_all
 
 .endif
 .endif

--- a/SoundEngine/famistudio_ca65.s
+++ b/SoundEngine/famistudio_ca65.s
@@ -6715,6 +6715,14 @@ famistudio_sfx_stop_all:
     ldx #FAMISTUDIO_SFX_CH3
     jsr famistudio_sfx_clear_channel
     .endif
+    .if FAMISTUDIO_CFG_DPCM_SUPPORT
+    lda famistudio_dpcm_effect ; Check if a sampled sfx is playing
+    beq @no_sample_sfx
+    lda #%00001111 ; Stop DPCM
+    sta FAMISTUDIO_APU_SND_CHN
+    rts
+    @no_sample_sfx
+    .endif
     rts 
 
 ;======================================================================================================================

--- a/SoundEngine/famistudio_cc65.h
+++ b/SoundEngine/famistudio_cc65.h
@@ -122,5 +122,17 @@ void __fastcall__ famistudio_sfx_play(unsigned char sfx_index, unsigned char cha
 
 void __fastcall__ famistudio_sfx_sample_play(unsigned char sample_index);
 
+/**
+ * ======================================================================================================================
+ * famistudio_sfx_stop_all (public)
+ *
+ * Stop all currently playing sound effects.
+ *
+ * [in] no input params.
+ * ======================================================================================================================
+ */
+
+void __fastcall__ famistudio_sfx_stop_all(void);
+
 #endif
 #endif

--- a/SoundEngine/famistudio_cc65.h
+++ b/SoundEngine/famistudio_cc65.h
@@ -135,4 +135,29 @@ void __fastcall__ famistudio_sfx_sample_play(unsigned char sample_index);
 void __fastcall__ famistudio_sfx_stop_all(void);
 
 #endif
+
+#ifdef FAMISTUDIO_CFG_MUTING_SUPPORT
+
+/**
+ * ======================================================================================================================
+ * famistudio_sfx_set_muting (public)
+ *
+ * Sets the muting mask for each channel, according to the following bit values:
+ * Bit 0 : Pulse 1 on
+ * Bit 1 : Pulse 2 on
+ * Bit 2 : Triangle on
+ * Bit 3 : Noise on
+ * Bit 4 : DPCM on
+ * Bit 5 : MMC5 Pulse 1/VRC6 Pulse 1 on
+ * Bit 6 : MMC5 Pulse 2/VRC6 Pulse 2 on
+ * Bit 7 : VRC6 Sawtooth on
+ * Note that the new mask will not take effect until the next time famistudio_update is called
+ *
+ * [in] mask: New mute mask value
+ * ======================================================================================================================
+ */
+
+void __fastcall__ famistudio_set_muting(unsigned char mute_mask);
+
+#endif
 #endif

--- a/SoundEngine/famistudio_multi_ca65.s
+++ b/SoundEngine/famistudio_multi_ca65.s
@@ -35,6 +35,7 @@
 ;   - famistudio_sfx_init        : Initialize SFX engine with SFX data.
 ;   - famistudio_sfx_play        : Play a SFX.
 ;   - famistudio_sfx_sample_play : Play a DPCM SFX.
+;   - famistudio_sfx_stop_all    : Stop currently playing SFX.
 ;   - famistudio_update          : Updates the music/SFX engine, call once per frame, ideally from NMI.
 ;
 ; You can check the demo ROM to see how they are used or check out the online documentation for more info.
@@ -1052,6 +1053,7 @@ famistudio_ptr1_hi = famistudio_ptr1+1
 .endif
 .export famistudio_sfx_init
 .export famistudio_sfx_play
+.export famistudio_sfx_stop_all
 .exportzp FAMISTUDIO_SFX_CH0
 .exportzp FAMISTUDIO_SFX_CH1
 .exportzp FAMISTUDIO_SFX_CH2
@@ -6743,6 +6745,36 @@ famistudio_sfx_play:
     rts
 
 ;======================================================================================================================
+; FAMISTUDIO_SFX_STOP_ALL (public)
+;
+; Stops all playing sound effects.
+;
+; [in] no input params.
+;
+;======================================================================================================================
+
+famistudio_sfx_stop_all:
+
+    ; Stop all sound effect streams
+    .if FAMISTUDIO_CFG_SFX_STREAMS > 0
+    ldx #FAMISTUDIO_SFX_CH0
+    jsr famistudio_sfx_clear_channel
+    .endif
+    .if FAMISTUDIO_CFG_SFX_STREAMS > 1
+    ldx #FAMISTUDIO_SFX_CH1
+    jsr famistudio_sfx_clear_channel
+    .endif
+    .if FAMISTUDIO_CFG_SFX_STREAMS > 2
+    ldx #FAMISTUDIO_SFX_CH2
+    jsr famistudio_sfx_clear_channel
+    .endif
+    .if FAMISTUDIO_CFG_SFX_STREAMS > 3
+    ldx #FAMISTUDIO_SFX_CH3
+    jsr famistudio_sfx_clear_channel
+    .endif
+    rts
+
+;======================================================================================================================
 ; FAMISTUDIO_SFX_UPDATE (internal)
 ;
 ; Updates a single sound effect stream.
@@ -7921,6 +7953,9 @@ _famistudio_sfx_play:
 
 ; A = sample_index; So we can safely re-export the symbol
 .export _famistudio_sfx_sample_play=famistudio_sfx_sample_play
+
+; No parameters so its safe to re-export
+.export _famistudio_sfx_stop_all=famistudio_sfx_stop_all
 
 .endif
 .endif

--- a/SoundEngine/famistudio_multi_ca65.s
+++ b/SoundEngine/famistudio_multi_ca65.s
@@ -6772,6 +6772,14 @@ famistudio_sfx_stop_all:
     ldx #FAMISTUDIO_SFX_CH3
     jsr famistudio_sfx_clear_channel
     .endif
+    .if FAMISTUDIO_CFG_DPCM_SUPPORT
+    lda famistudio_dpcm_effect ; Check if a sampled sfx is playing
+    beq @no_sample_sfx
+    lda #%00001111 ; Stop DPCM
+    sta FAMISTUDIO_APU_SND_CHN
+    rts
+    @no_sample_sfx:
+    .endif
     rts
 
 ;======================================================================================================================


### PR DESCRIPTION
This adds two extra functions to the sound engine that gives developers additional control over playback:
- `famistudio_sfx_stop_all` will instantly stop any currently playing sound effects (including samples), which can be useful for pause screens, stage transitions, and other similar situations.
- `famistudio_set_muting` and its corresponding configuration flag `FAMISTUDIO_CFG_MUTING_SUPPORT` allows the program to selectively mute and unmute sound channels while leaving any sound effects on those channels untouched, at the expense of an extra byte used to store the muting settings. This has a wide range of applications (muting the pulse channels on a menu screen, unmuting the noise channel as the player enters a battle, etc.), although it can only apply to channels on the 2A03, MMC5 and VRC6 at the moment, and has been left out of the multi-expansion sound engine due to a lack of knowledge and resources necessary to test it.