### PR TITLE
Fix pasting bug which affects several expansion channels

### DIFF
--- a/FamiStudio/Source/Utils/ClipboardUtils.cs
+++ b/FamiStudio/Source/Utils/ClipboardUtils.cs
@@ -141,14 +141,14 @@ namespace FamiStudio
                         {
                             if (!checkOnly)
                             {
-                                var chan = song.GetChannelByType(patChannel);
+                                var channel = song.GetChannelByType(patChannel);
 
                                 if (existingPattern != null)
                                 {
-                                    patName = chan.GenerateUniquePatternNameSmart(patName);
+                                    patName = channel.GenerateUniquePatternNameSmart(patName);
                                 }
 
-                                var pattern = chan.CreatePattern(patName);
+                                var pattern = channel.CreatePattern(patName);
                                 serializer.RemapId(patId, pattern.Id);
                                 pattern.Serialize(serializer);
                                 pattern.Name = patName;

--- a/FamiStudio/Source/Utils/ClipboardUtils.cs
+++ b/FamiStudio/Source/Utils/ClipboardUtils.cs
@@ -143,7 +143,7 @@ namespace FamiStudio
                             {
                                 if (existingPattern != null)
                                 {
-                                    patName = song.Channels[patChannel].GenerateUniquePatternNameSmart(patName);
+                                    patName = song.GetChannelByType(patChannel).GenerateUniquePatternNameSmart(patName);
                                 }
 
                                 var pattern = song.GetChannelByType(patChannel).CreatePattern(patName);

--- a/FamiStudio/Source/Utils/ClipboardUtils.cs
+++ b/FamiStudio/Source/Utils/ClipboardUtils.cs
@@ -141,12 +141,14 @@ namespace FamiStudio
                         {
                             if (!checkOnly)
                             {
+                                var chan = song.GetChannelByType(patChannel);
+
                                 if (existingPattern != null)
                                 {
-                                    patName = song.GetChannelByType(patChannel).GenerateUniquePatternNameSmart(patName);
+                                    patName = chan.GenerateUniquePatternNameSmart(patName);
                                 }
 
-                                var pattern = song.GetChannelByType(patChannel).CreatePattern(patName);
+                                var pattern = chan.CreatePattern(patName);
                                 serializer.RemapId(patId, pattern.Id);
                                 pattern.Serialize(serializer);
                                 pattern.Name = patName;


### PR DESCRIPTION
To replicate this bug:
* Create a new project and add one of the affected expansions
* Create a pattern in a channel for the expansion
* Place note(s) in the pattern
* Copy the pattern to the clipboard and then delete it (alternatively just cut it)
* Create a new pattern for the same channel (it will now have the same name as the one you previously deleted / cut)
* Paste the pattern from the clipboard, overwriting the new one
* Select "Rename the pasted pattern(s) and create new one(s)"
* Out of range exception

___
The channel type was being accessed by index while pasting, which doesn't actually match on the majority of expansions and ends up being out of range.

Example, a song with only FDS will have index 5 for the collection song.Channels, but it will try to access it as 14 (out of range), crashing the app. Getting the channel by type should always be correct.

Also tidied up redundancy instead of needing to get the channel twice.