### PR TITLE
Wayland scaling fix / workaround

### DIFF
--- a/FamiStudio/Source/App/Desktop/FamiStudioWindow.cs
+++ b/FamiStudio/Source/App/Desktop/FamiStudioWindow.cs
@@ -81,6 +81,7 @@ namespace FamiStudio
         GLFWdropfun dropCallback;
 
         private static bool isWayland = false;
+        private static float scaleModifer = 1f;
 
         public FamiStudioWindow(FamiStudio app, IntPtr glfwWindow)
         {
@@ -411,6 +412,16 @@ namespace FamiStudio
             RefreshLayout();
         }
 
+        private void WindowContentScaleCallback(IntPtr window, float scaling, float _)
+        {
+            Debug.WriteLine($"*** RESCALED: {scaling}");
+
+            if (isWayland)
+            {
+                scaleModifer = scaling / DpiScaling.Window;
+            }
+        }
+
         private void WindowCloseCallback(IntPtr window)
         {
             if (IsAsyncDialogInProgress)
@@ -424,12 +435,12 @@ namespace FamiStudio
 
         public static void GLFWToWindow(double dx, double dy, out int x, out int y)
         {
-            if ((Platform.IsMacOS || Platform.IsLinux && isWayland) && DpiScaling.IsInitialized)
+            if ((Platform.IsMacOS || (Platform.IsLinux && isWayland)) && DpiScaling.IsInitialized)
             {
                 Debug.Assert(!DpiScaling.ForceUnitScaling);
 
-                x = (int)Math.Round(dx * DpiScaling.Window);
-                y = (int)Math.Round(dy * DpiScaling.Window);
+                x = (int)Math.Round(dx * (DpiScaling.Window * scaleModifer));
+                y = (int)Math.Round(dy * (DpiScaling.Window * scaleModifer));
             }
             else
             {
@@ -442,11 +453,6 @@ namespace FamiStudio
         {
             Debug.WriteLine($"WINDOW REFRESH!");
             MarkDirty();
-        }
-
-        private void WindowContentScaleCallback(IntPtr window, float xscale, float _)
-        {
-            Debug.WriteLine($"*** WINDOW CONTENT SCALED: {xscale}");
         }
 
         private void MouseButtonCallback(IntPtr window, int button, int action, int mods)

--- a/FamiStudio/Source/App/Desktop/FamiStudioWindow.cs
+++ b/FamiStudio/Source/App/Desktop/FamiStudioWindow.cs
@@ -70,6 +70,7 @@ namespace FamiStudio
         GLFWwindowsizefun windowSizeCallback;
         GLFWwindowclosefun windowCloseCallback;
         GLFWwindowrefreshfun windowRefreshCallback;
+        GLFWwindowcontentscalefun windowContentScaleCallback;
         GLFWmousebuttonfun mouseButtonCallback;
         GLFWcursorposfun cursorPosCallback;
         GLFWcursorenterfun cursorEnterCallback;
@@ -103,6 +104,7 @@ namespace FamiStudio
             windowSizeCallback = new GLFWwindowsizefun(WindowSizeCallback);
             windowCloseCallback = new GLFWwindowclosefun(WindowCloseCallback);
             windowRefreshCallback = new GLFWwindowrefreshfun(WindowRefreshCallback);
+            windowContentScaleCallback = new GLFWwindowcontentscalefun(WindowContentScaleCallback);
             mouseButtonCallback = new GLFWmousebuttonfun(MouseButtonCallback);
             cursorPosCallback = new GLFWcursorposfun(CursorPosCallback);
             cursorEnterCallback = new GLFWcursorenterfun(CursorEnterCallback);
@@ -119,6 +121,7 @@ namespace FamiStudio
             glfwSetWindowSizeCallback(window, windowSizeCallback);
             glfwSetWindowCloseCallback(window, windowCloseCallback);
             glfwSetWindowRefreshCallback(window, windowRefreshCallback);
+            glfwSetWindowContentScaleCallback(window, windowContentScaleCallback);
             glfwSetMouseButtonCallback(window, mouseButtonCallback);
             glfwSetCursorPosCallback(window, cursorPosCallback);
             glfwSetCursorEnterCallback(window, cursorEnterCallback);
@@ -439,6 +442,11 @@ namespace FamiStudio
         {
             Debug.WriteLine($"WINDOW REFRESH!");
             MarkDirty();
+        }
+
+        private void WindowContentScaleCallback(IntPtr window, float xscale, float _)
+        {
+            Debug.WriteLine($"*** WINDOW CONTENT SCALED: {xscale}");
         }
 
         private void MouseButtonCallback(IntPtr window, int button, int action, int mods)

--- a/FamiStudio/Source/App/Desktop/FamiStudioWindow.cs
+++ b/FamiStudio/Source/App/Desktop/FamiStudioWindow.cs
@@ -395,7 +395,7 @@ namespace FamiStudio
         {
             // Under Wayland, the callback spams errors about the window position.
             // This slows everything to a crawl while debugging, so we mitigate it.
-            if (glfwGetPlatform() == GLFW_PLATFORM_WAYLAND && description.Contains("window position"))
+            if (isWayland && description.Contains("window position"))
                 return;
 
             Debug.WriteLine($"*** GLFW Error code {error}, {description}.");

--- a/FamiStudio/Source/App/Desktop/FamiStudioWindow.cs
+++ b/FamiStudio/Source/App/Desktop/FamiStudioWindow.cs
@@ -81,7 +81,7 @@ namespace FamiStudio
         GLFWdropfun dropCallback;
 
         private static bool isWayland = false;
-        private static float scaleModifer = 1f;
+        private static float scaleModifier = 1f;
 
         public FamiStudioWindow(FamiStudio app, IntPtr glfwWindow)
         {
@@ -418,7 +418,7 @@ namespace FamiStudio
 
             if (isWayland)
             {
-                scaleModifer = scaling / DpiScaling.Window;
+                scaleModifier = scaling / DpiScaling.Window;
             }
         }
 
@@ -439,8 +439,8 @@ namespace FamiStudio
             {
                 Debug.Assert(!DpiScaling.ForceUnitScaling);
 
-                x = (int)Math.Round(dx * (DpiScaling.Window * scaleModifer));
-                y = (int)Math.Round(dy * (DpiScaling.Window * scaleModifer));
+                x = (int)Math.Round(dx * (DpiScaling.Window * scaleModifier));
+                y = (int)Math.Round(dy * (DpiScaling.Window * scaleModifier));
             }
             else
             {

--- a/FamiStudio/Source/App/Desktop/FamiStudioWindow.cs
+++ b/FamiStudio/Source/App/Desktop/FamiStudioWindow.cs
@@ -79,6 +79,8 @@ namespace FamiStudio
         GLFWcharmodsfun charModsCallback;
         GLFWdropfun dropCallback;
 
+        private static bool isWayland = false;
+
         public FamiStudioWindow(FamiStudio app, IntPtr glfwWindow)
         {
             famistudio = app;
@@ -202,6 +204,8 @@ namespace FamiStudio
                 glfwTerminate();
                 return null;
             }
+
+            isWayland = glfwGetPlatform() == GLFW_PLATFORM_WAYLAND;
 
             glfwMakeContextCurrent(window);
             glfwSetWindowSizeLimits(window, 400, 300, GLFW_DONT_CARE, GLFW_DONT_CARE);
@@ -417,7 +421,7 @@ namespace FamiStudio
 
         public static void GLFWToWindow(double dx, double dy, out int x, out int y)
         {
-            if (Platform.IsMacOS && DpiScaling.IsInitialized)
+            if ((Platform.IsMacOS || Platform.IsLinux && isWayland) && DpiScaling.IsInitialized)
             {
                 Debug.Assert(!DpiScaling.ForceUnitScaling);
 

--- a/FamiStudio/Source/App/Desktop/FamiStudioWindow.cs
+++ b/FamiStudio/Source/App/Desktop/FamiStudioWindow.cs
@@ -439,8 +439,8 @@ namespace FamiStudio
             {
                 Debug.Assert(!DpiScaling.ForceUnitScaling);
 
-                x = (int)Math.Round(dx * (DpiScaling.Window * scaleModifier));
-                y = (int)Math.Round(dy * (DpiScaling.Window * scaleModifier));
+                x = (int)Math.Round(dx * DpiScaling.Window * scaleModifier);
+                y = (int)Math.Round(dy * DpiScaling.Window * scaleModifier);
             }
             else
             {


### PR DESCRIPTION
When opening the app on Wayland at any DPI scaling other than 100%, it was completely broken. The window was the wrong size, and the cursor was clicking in the wrong place etc.

Changes:
* Wayland will use the same scaling code as MacOS, so that it opens correctly with DPI scaling applied
* Scaling while the app is open (or switching a monitor with different scaling) on Wayland now behaves like Windows

Note: Scaling will not apply if changed while the app is running. This includes switching to another monitor with different scaling. This is exactly how Windows behaves, rather than the app malfunctioning.

This does not affect any other OS other than Linux running Wayland.