### PR TITLE
Fix discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ You can find me:
 - On Twitter [@NesBleuBleu](http://www.twitter.com/nesbleubleu)
 - On [YouTube](https://www.youtube.com/channel/UC-dGLo2XZqXNA_aOYjaucgA?view_as=subscriber)
 - On [Itch.io](https://bleubleu.itch.io/famistudio)
-- On the [FamiStudio Discord](https://discord.gg/88UPmxh)
+- On the [FamiStudio Discord](https://discord.gg/QRCMe595Pv)


### PR DESCRIPTION
Before this change, the discord link in readme.md doesn't work. After this PR, it is replaced with the working link in TODO.txt.