### PR TITLE
Russian localization DPCM Export Mode locale update

### DIFF
--- a/FamiStudio/Localization/FamiStudio.rus.ini
+++ b/FamiStudio/Localization/FamiStudio.rus.ini
@@ -330,8 +330,8 @@ FT2AssemblyTooltip=Ассемблер, который будет использ�
 FT2SepFilesTooltip=Если эта опция включена, каждый трек экспортируется в отдельный файл.
 FT2SepFilesFmtTooltip=Формат для имён каждого файла при использовании отдельных файлов.
 FT2DmcFmtTooltip=Формат имени файла DMC. Файл DMC создаётся только в том случае, если в проекте используются семплы DPCM.
-FT2DmcExportModeTooltip=Which DPCM samples to include in the exported data. #TODO!
-FT2ExportUnusedMappingsLabel=If enabled, DPCM sample mappings not used directly in any songs(s) but referencing exported samples will still be exported. #TODO!
+FT2DmcExportModeTooltip=Семплы DPCM, которые будут включены в экспорт.
+FT2ExportUnusedMappingsLabel=Если эта опция включена, в экспорт будут включены назначения всех экспортированных семплов DPCM, даже если они не используются напрямую в треках.
 FT2BankswitchTooltip=Если эта опция включена, экспортируемые данные будут предполагать использование нескольких банков данных DPCM, даже если в текущем проекте недостаточно семплов, чтобы оправдать это.
 FT2SongListTooltip=Если эта опция включена, создаётся файл .inc, содержащий информацию о каждом треке.
 FT2SfxSongListTooltip=Если эта опция включена, создаётся файл .inc, содержащий информацию о каждом звуковом эффекте.
@@ -342,9 +342,9 @@ SoundEngineMultExpLabel=Звуковой движок FamiStudio поддерж�
 SeparateFilesLabel=Отдельные файлы
 SongNamePatternLabel=Шаблон названия треков
 DmcNamePatternLabel=Шаблон названия DMC
-DmcExportModeLabel=DMC Export Mode #TODO!
-ExportUnusedMappingsLabel=Export unused mappings #TODO!
-ForceDpcmBankSwitchingLabel=Принудительное переключение банка данных DPCM
+DmcExportModeLabel=Режим экспорта семплов DPCM
+ExportUnusedMappingsLabel=Экспортировать все назн. DPCM
+ForceDpcmBankSwitchingLabel=Принуд. переключ. банка данных DPCM #this is unused lmao
 GenerateSongListIncludeLabel=Сгенерировать список треков
 
 # Share tooltips.
@@ -1535,7 +1535,7 @@ DialogErrorMessage=Не удалось отобразить диалоговое
 CopyLogTextContext=Копировать текст журнала
 
 [DpcmExportMode]
-LocalizedNames_0=All samples #TODO!
-LocalizedNames_1=Mapped samples (any instrument) #TODO!
-LocalizedNames_2=Mapped samples (only used instruments) #TODO!
-LocalizedNames_3=Minimum required to play song(s) #TODO!
+LocalizedNames_0=Все семплы
+LocalizedNames_1=Назнач. на все инструменты
+LocalizedNames_2=Назнач. на использ. инструменты
+LocalizedNames_3=Минимум


### PR DESCRIPTION
Localization has been tested to fully work on 1280px-wide monitors.