### PR TITLE
Fix incorrect effects on song change

### DIFF
--- a/FamiStudio/Source/App/Common/FamiStudio.cs
+++ b/FamiStudio/Source/App/Common/FamiStudio.cs
@@ -261,7 +261,7 @@ namespace FamiStudio
                     ResetSelectedChannel();
                     RefreshLayout();
                     ProjectExplorer.SelectedSongChanged();
-                    PianoRoll.SongChanged(selectedChannelIndex);
+                    PianoRoll.SongChanged(0);
                     Sequencer.Reset();
                     ToolBar.Reset();
 


### PR DESCRIPTION
On song change, the effects from the previously selected channel type would show instead of the correct ones, meaning a channel had to be toggled back and forth to fix the effects.