### PR TITLE
Fix crash when exporting music if there are songs with duplicate dpcm mappings

### DIFF
--- a/FamiStudio/Source/IO/FamitoneMusicFile.cs
+++ b/FamiStudio/Source/IO/FamitoneMusicFile.cs
@@ -190,7 +190,10 @@ namespace FamiStudio
                         if (inst.SamplesMapping == null) continue;
                         foreach (var mapping in inst.SamplesMapping.Values)
                         {
-                            sampleMappingIndices.Add(mapping, 0);
+                            if (!sampleMappingIndices.TryAdd(mapping, 0))
+                            {
+                                Log.LogMessage(LogSeverity.Debug, $"Found a duplicate mapping.");
+                            }
 
                             if (sampleMappingIndices.Count >= maxMappings)
                             {


### PR DESCRIPTION
If the DPCM mapping already exists from a different song when exporting all DPCM samples, it causes the application to crash when exporting all samples (even unused samples). Added a debug log when the duplicate mappings are found in case this is something we need to investigate further someday.