### PR TITLE
4.5.4 Hotfix Stuff

### DIFF
--- a/FamiStudio/Source/App/Common/Controls/Grid.cs
+++ b/FamiStudio/Source/App/Common/Controls/Grid.cs
@@ -757,7 +757,11 @@ namespace FamiStudio
                 {
                     for (var j = 0; j < ItemCount; j++)
                     {
-                        data[j, i] = check;
+                        if ((bool)data[j, i] != check)
+                        {
+                            data[j, i] = check;
+                            ValueChanged?.Invoke(this, j, i, check);
+                        }
                     }
                 }
             }

--- a/FamiStudio/Source/App/Common/Controls/Sequencer/Sequencer.cs
+++ b/FamiStudio/Source/App/Common/Controls/Sequencer/Sequencer.cs
@@ -68,6 +68,7 @@ namespace FamiStudio
         int capturePatternIdx = -1;
         int dragSeekPosition = -1;
         int selectionDragAnchorPatternIdx = -1;
+        int lastTappedChanIdx = -1;
         float zoom = DefaultZoom;
         float bitmapScale = 1.0f;
         float channelBitmapScale = 1.0f;
@@ -1759,12 +1760,15 @@ namespace FamiStudio
 
         private bool HandleTouchClickChannelName(int x, int y, bool doubleClick = false)
         {
+            // HACK: Since the sequencer doesn't use real buttons, we keep the last tapped channel index.
+            // This prevents an issue on mobile, where tapping two icons that are close together sends
+            // a double tap, toggling solo channel. Note: Usually only doable with small channel Y size.
             if (IsMouseInTrackName(x, y))
             {
                 var chanIdx = GetChannelIndexFromIconPos(x, y);
                 if (chanIdx >= 0)
                 {
-                    if (doubleClick)
+                    if (doubleClick && lastTappedChanIdx == chanIdx) 
                     {
                         App.ToggleChannelSolo(chanIdx, true);
                     }
@@ -1772,13 +1776,15 @@ namespace FamiStudio
                     {
                         App.ToggleChannelActive(chanIdx);
                     }
+
+                    lastTappedChanIdx = chanIdx;
                     return true;
                 }
 
                 chanIdx = GetChannelIndexFromGhostIconPos(x, y);
                 if (chanIdx >= 0)
                 {
-                    if (doubleClick) 
+                    if (doubleClick && lastTappedChanIdx == chanIdx) 
                     { 
                         App.ToggleChannelForceDisplayAll(chanIdx, true);
                     }
@@ -1786,10 +1792,13 @@ namespace FamiStudio
                     {
                         App.ToggleChannelForceDisplay(chanIdx);
                     }
+
+                    lastTappedChanIdx = chanIdx;
                     return true;
                 }
             }
 
+            lastTappedChanIdx = -1;
             return false;
         }
 

--- a/FamiStudio/Source/App/Common/Controls/Sequencer/Sequencer.cs
+++ b/FamiStudio/Source/App/Common/Controls/Sequencer/Sequencer.cs
@@ -1766,9 +1766,10 @@ namespace FamiStudio
             if (IsMouseInTrackName(x, y))
             {
                 var chanIdx = GetChannelIndexFromIconPos(x, y);
+                var canToggleSolo = Platform.IsDesktop || lastTappedChanIdx == chanIdx;
                 if (chanIdx >= 0)
                 {
-                    if (doubleClick && lastTappedChanIdx == chanIdx) 
+                    if (doubleClick && canToggleSolo)
                     {
                         App.ToggleChannelSolo(chanIdx, true);
                     }
@@ -1784,7 +1785,7 @@ namespace FamiStudio
                 chanIdx = GetChannelIndexFromGhostIconPos(x, y);
                 if (chanIdx >= 0)
                 {
-                    if (doubleClick && lastTappedChanIdx == chanIdx) 
+                    if (doubleClick && canToggleSolo)
                     { 
                         App.ToggleChannelForceDisplayAll(chanIdx, true);
                     }

--- a/FamiStudio/Source/App/Common/Controls/Sequencer/Sequencer.cs
+++ b/FamiStudio/Source/App/Common/Controls/Sequencer/Sequencer.cs
@@ -68,7 +68,7 @@ namespace FamiStudio
         int capturePatternIdx = -1;
         int dragSeekPosition = -1;
         int selectionDragAnchorPatternIdx = -1;
-        int lastTappedChanIdx = -1;
+        int lastChanIdx = -1;
         float zoom = DefaultZoom;
         float bitmapScale = 1.0f;
         float channelBitmapScale = 1.0f;
@@ -1410,6 +1410,8 @@ namespace FamiStudio
             if (e.Left && IsMouseInTrackName(e.X, e.Y))
             { 
                 var chanIdx = GetChannelIndexFromIconPos(e.X, e.Y);
+                lastChanIdx = chanIdx;
+
                 if (chanIdx >= 0)
                 {
                     App.ToggleChannelActive(chanIdx);
@@ -1766,7 +1768,9 @@ namespace FamiStudio
             if (IsMouseInTrackName(x, y))
             {
                 var chanIdx = GetChannelIndexFromIconPos(x, y);
-                var canToggleSolo = Platform.IsDesktop || lastTappedChanIdx == chanIdx;
+                var canToggleSolo = lastChanIdx == chanIdx;
+                lastChanIdx = chanIdx;
+
                 if (chanIdx >= 0)
                 {
                     if (doubleClick && canToggleSolo)
@@ -1777,8 +1781,6 @@ namespace FamiStudio
                     {
                         App.ToggleChannelActive(chanIdx);
                     }
-
-                    lastTappedChanIdx = chanIdx;
                     return true;
                 }
 
@@ -1793,13 +1795,10 @@ namespace FamiStudio
                     {
                         App.ToggleChannelForceDisplay(chanIdx);
                     }
-
-                    lastTappedChanIdx = chanIdx;
                     return true;
                 }
             }
 
-            lastTappedChanIdx = -1;
             return false;
         }
 

--- a/FamiStudio/Source/App/Common/Controls/Toolbar/Oscilloscope.cs
+++ b/FamiStudio/Source/App/Common/Controls/Toolbar/Oscilloscope.cs
@@ -21,8 +21,7 @@ namespace FamiStudio
             var sx = width;
             var sy = height;
 
-            c.PushClipRegion(1, 1, sx - 1, sy - 1);
-            c.FillRectangle(0, 0, sx, sy, Theme.BlackColor);
+            c.FillAndDrawRectangle(0, 0, sx, sy, Theme.BlackColor, Theme.LightGreyColor2);
 
             var oscilloscopeGeometry = App.GetOscilloscopeGeometry(out lastOscilloscopeHadNonZeroSample);
 
@@ -49,9 +48,6 @@ namespace FamiStudio
                 if (betaNumber > 0)
                     c.DrawText($"BETA {betaNumber}", Fonts.FontSmall, 4, 4, Theme.LightRedColor);
             }
-
-            c.PopClipRegion();
-            c.DrawRectangle(0, 0, sx, sy, Theme.LightGreyColor2);
         }
     }
 }

--- a/FamiStudio/Source/App/Mobile/CheckBoxList.cs
+++ b/FamiStudio/Source/App/Mobile/CheckBoxList.cs
@@ -70,7 +70,8 @@ namespace FamiStudio
         {
             foreach (var chk in checkList)
             {
-                chk.Checked = check;
+                if (chk.Checked != check)
+                    chk.Checked = check;
             }
         }
 

--- a/FamiStudio/Source/AudioStreams/AndroidAudioStream.cs
+++ b/FamiStudio/Source/AudioStreams/AndroidAudioStream.cs
@@ -27,6 +27,7 @@ namespace FamiStudio
         private Task playingTask;
         private int inputSampleRate;
         private int outputSampleRate;
+        private short[] mixSamples;
         private short[] lastSamples;
         private double resampleIndex = 0.0;
         private volatile ImmediateData immediateData = null;
@@ -133,7 +134,14 @@ namespace FamiStudio
                 var newSamples = bufferFill(out var done);
                 if (newSamples != null)
                 {
-                    newSamples = MixImmediateData(newSamples); 
+                    // Use separate collection during MixImmediateData. Modifying the buffer
+                    // in place causes the oscilloscope to react.
+                    if (mixSamples?.Length != newSamples.Length)
+                        mixSamples = new short[newSamples.Length];
+
+                    Array.Copy(newSamples, mixSamples, newSamples.Length);
+
+                    newSamples = MixImmediateData(mixSamples);
                     lastSamples = WaveUtils.ResampleStream(lastSamples, newSamples, inputSampleRate, outputSampleRate, stereo, ref resampleIndex);
                     audioTrack.Write(lastSamples, 0, lastSamples.Length, WriteMode.Blocking);
                 }

--- a/FamiStudio/Source/AudioStreams/AndroidAudioStream.cs
+++ b/FamiStudio/Source/AudioStreams/AndroidAudioStream.cs
@@ -27,7 +27,6 @@ namespace FamiStudio
         private Task playingTask;
         private int inputSampleRate;
         private int outputSampleRate;
-        private short[] mixSamples;
         private short[] lastSamples;
         private double resampleIndex = 0.0;
         private volatile ImmediateData immediateData = null;
@@ -134,14 +133,7 @@ namespace FamiStudio
                 var newSamples = bufferFill(out var done);
                 if (newSamples != null)
                 {
-                    // Use separate collection during MixImmediateData. Modifying the buffer
-                    // in place causes the oscilloscope to react.
-                    if (mixSamples?.Length != newSamples.Length)
-                        mixSamples = new short[newSamples.Length];
-
-                    Array.Copy(newSamples, mixSamples, newSamples.Length);
-
-                    newSamples = MixImmediateData(mixSamples);
+                    newSamples = MixImmediateData(newSamples);
                     lastSamples = WaveUtils.ResampleStream(lastSamples, newSamples, inputSampleRate, outputSampleRate, stereo, ref resampleIndex);
                     audioTrack.Write(lastSamples, 0, lastSamples.Length, WriteMode.Blocking);
                 }
@@ -165,13 +157,16 @@ namespace FamiStudio
             var immData = immediateData;
             if (immData != null && immData.samplesOffset < immData.samples.Length)
             {
+                // Clone to avoid mixing immediate data into oscilloscope.
+                var mixedSamples = (short[])samples.Clone();
                 var channelCount = stereo ? 2 : 1;
-                var sampleCount = Math.Min(samples.Length, (immData.samples.Length - immData.samplesOffset) * channelCount);
+                var sampleCount = Math.Min(mixedSamples.Length, (immData.samples.Length - immData.samplesOffset) * channelCount);
 
                 for (int i = 0, j = immData.samplesOffset; i < sampleCount; i++, j += (i % channelCount) == 0 ? 1 : 0)
-                    samples[i] = (short)Math.Clamp(samples[i] + immData.samples[j], short.MinValue, short.MaxValue);
+                    mixedSamples[i] = (short)Math.Clamp(mixedSamples[i] + immData.samples[j], short.MinValue, short.MaxValue);
 
                 immData.samplesOffset += sampleCount / channelCount;
+                return mixedSamples;
             }
 
             return samples;

--- a/FamiStudio/Source/IO/NsfFile.cs
+++ b/FamiStudio/Source/IO/NsfFile.cs
@@ -1293,7 +1293,7 @@ namespace FamiStudio
 
                         // We scale all pitches changes (slides, fine pitch, pitch envelopes) for
                         // some channels with HUGE pitch values (N163, VRC7).
-                        finePitch >>= pitchShift;
+                        finePitch = Math.Sign(finePitch) * (Math.Abs(finePitch) >> pitchShift);
 
                         var pitch = (sbyte)Utils.Clamp(finePitch, Note.FinePitchMin, Note.FinePitchMax);
 

--- a/FamiStudio/Source/IO/NsfFile.cs
+++ b/FamiStudio/Source/IO/NsfFile.cs
@@ -1244,10 +1244,10 @@ namespace FamiStudio
                 if ((state.period != period) || (hasOctave && state.octave != octave) || (instrument != state.instrument) || force)
                 {
                     var noteTable = NesApu.GetNoteTableForChannelType(channel.Type, project.PalMode, project.ExpansionNumN163Channels, project.Tuning);
-                    var note = release ? Note.NoteRelease : (stop ? Note.NoteStop : state.note);
+                    var note = stop ? Note.NoteStop : state.note;
                     var finePitch = 0;
 
-                    if (!stop && !release && state.state != ChannelState.Stopped)
+                    if (!stop && state.state != ChannelState.Stopped)
                     {
                         if (channel.Type == ChannelType.Noise)
                             note = (period ^ 0x0f) + 32;
@@ -1266,6 +1266,11 @@ namespace FamiStudio
                             note = Math.Min(note, noteTable.Length - 1);
                             finePitch = period - noteTable[note];
                         }
+
+                        // The logic above needs to be done for fine pitch, otherwise
+                        // it resets to 0 on release, which is incorrect.
+                        if (release)
+                            note = Note.NoteRelease;
                     }
 
                     if (note < Note.MusicalNoteMin || note > Note.MusicalNoteMax)

--- a/FamiStudio/Source/IO/VgmFile.cs
+++ b/FamiStudio/Source/IO/VgmFile.cs
@@ -1587,7 +1587,7 @@ namespace FamiStudio
 
                         // We scale all pitches changes (slides, fine pitch, pitch envelopes) for
                         // some channels with HUGE pitch values (N163, VRC7).
-                        finePitch >>= pitchShift;
+                        finePitch = Math.Sign(finePitch) * (Math.Abs(finePitch) >> pitchShift);
 
                         var pitch = (sbyte)Utils.Clamp(finePitch, Note.FinePitchMin, Note.FinePitchMax);
 

--- a/FamiStudio/Source/IO/VgmFile.cs
+++ b/FamiStudio/Source/IO/VgmFile.cs
@@ -1594,12 +1594,11 @@ namespace FamiStudio
                         // some channels with HUGE pitch values (N163, VRC7).
                         finePitch = Math.Sign(finePitch) * (Math.Abs(finePitch) >> pitchShift);
 
-                        var pitch = release ? (sbyte)state.pitch : (sbyte)Utils.Clamp(finePitch, Note.FinePitchMin, Note.FinePitchMax);
+                        var pitch = (sbyte)Utils.Clamp(finePitch, Note.FinePitchMin, Note.FinePitchMax);
 
                         if (pitch != state.pitch)
                         {
-                            var pattern = channel.GetOrCreatePattern(p).GetOrCreateNoteAt(n);
-                            pattern.FinePitch = pitch;
+                            var pattern = channel.GetOrCreatePattern(p).GetOrCreateNoteAt(n).FinePitch = pitch;
                             state.pitch = pitch;
                         }
                     }

--- a/FamiStudio/Source/IO/VgmFile.cs
+++ b/FamiStudio/Source/IO/VgmFile.cs
@@ -1513,10 +1513,10 @@ namespace FamiStudio
                 if ((state.period != period) || (hasOctave && state.octave != octave) || (instrument != state.instrument) || force)
                 {
                     var noteTable = NesApu.GetNoteTableForChannelType(channel.Type, project.PalMode, project.ExpansionNumN163Channels, project.Tuning);
-                    var note = release ? Note.NoteRelease : (stop ? Note.NoteStop : state.note);
+                    var note = stop ? Note.NoteStop : state.note;
                     var finePitch = 0;
 
-                    if (!stop && !release && state.state != ChannelState.Stopped)
+                    if (!stop && state.state != ChannelState.Stopped)
                     {
                         if (channel.Type == ChannelType.Noise)
                             note = (period ^ 0x0f) + 32;
@@ -1556,6 +1556,11 @@ namespace FamiStudio
                             note = Math.Min(note, noteTable.Length - 1);
                             finePitch = period - noteTable[note];
                         }
+
+                        // The logic above needs to be done for fine pitch, otherwise
+                        // it resets to 0 on release, which is incorrect.
+                        if (release)
+                            note = Note.NoteRelease;
                     }
 
                     if (note < Note.MusicalNoteMin || note > Note.MusicalNoteMax)
@@ -1589,11 +1594,12 @@ namespace FamiStudio
                         // some channels with HUGE pitch values (N163, VRC7).
                         finePitch = Math.Sign(finePitch) * (Math.Abs(finePitch) >> pitchShift);
 
-                        var pitch = (sbyte)Utils.Clamp(finePitch, Note.FinePitchMin, Note.FinePitchMax);
+                        var pitch = release ? (sbyte)state.pitch : (sbyte)Utils.Clamp(finePitch, Note.FinePitchMin, Note.FinePitchMax);
 
                         if (pitch != state.pitch)
                         {
-                            var pattern = channel.GetOrCreatePattern(p).GetOrCreateNoteAt(n).FinePitch = pitch;
+                            var pattern = channel.GetOrCreatePattern(p).GetOrCreateNoteAt(n);
+                            pattern.FinePitch = pitch;
                             state.pitch = pitch;
                         }
                     }

--- a/FamiStudio/Source/IO/VgmFile.cs
+++ b/FamiStudio/Source/IO/VgmFile.cs
@@ -2434,13 +2434,13 @@ namespace FamiStudio
                     Log.LogMessage(LogSeverity.Info, "Track Name: " + gd3DataArray[0]);
                     songName = gd3DataArray[0];
                     Log.LogMessage(LogSeverity.Info, "Game Name: " + gd3DataArray[2]);
-                    project.Name = gd3DataArray[2] + gd3DataArray[4];
+                    project.Name = gd3DataArray[2]; // + gd3DataArray[4] was here, no idea why we would want that?
                     Log.LogMessage(LogSeverity.Info, "System Name: " + gd3DataArray[4]);
                     Log.LogMessage(LogSeverity.Info, "Original Author Name: " + gd3DataArray[6]);
-                    project.Copyright = gd3DataArray[6];
+                    project.Author = gd3DataArray[6]; // We want the actual author, not the "converted by" field.
+                    project.Copyright = gd3DataArray[8]; // Others use the year for copyright.
                     Log.LogMessage(LogSeverity.Info, "Release Date: " + gd3DataArray[8]);
                     Log.LogMessage(LogSeverity.Info, "Converted by: " + gd3DataArray[9]);
-                    project.Author = gd3DataArray[9];
                     Log.LogMessage(LogSeverity.Info, "Notes: " + gd3DataArray[10]);
                 }
             }

--- a/FamiStudio/Source/Project/Song.cs
+++ b/FamiStudio/Source/Project/Song.cs
@@ -1277,7 +1277,9 @@ namespace FamiStudio
 
                             if (!noteWillStop)
                             {
-                                lastNotes[c] = it.Note.Clone();
+                                // Reference the last note for DPCM rather than cloning it. Notes with
+                                // no attack still retrigger for DPCM, we don't want that in this case.
+                                lastNotes[c] = channel.Type == ChannelType.Dpcm ? it.Note : it.Note.Clone();
                             }
 
                             break;
@@ -1313,11 +1315,20 @@ namespace FamiStudio
                             {
                                 var lastNote = lastNotes[c];
                                 channel.PatternInstances[i] = channel.PatternInstances[i] == null ? channel.CreatePattern() : channel.PatternInstances[i].ShallowClone();
-                                note = channel.PatternInstances[i].GetOrCreateNoteAt(0);
-                                note.Value = lastNote.IsSlideNote ? lastNote.SlideNoteTarget : lastNote.Value;
-                                note.Instrument = lastNote.Instrument;
-                                note.HasAttack = false;
-                                note.Duration = 1000000;
+
+                                // Simply extend the last note for DPCM to prevent a retrigger.
+                                if (channel.Type == ChannelType.Dpcm)
+                                {
+                                    lastNote.Duration = 1000000;
+                                }
+                                else
+                                {
+                                    note = channel.PatternInstances[i].GetOrCreateNoteAt(0);
+                                    note.Value = lastNote.IsSlideNote ? lastNote.SlideNoteTarget : lastNote.Value;
+                                    note.Instrument = lastNote.Instrument;
+                                    note.HasAttack = false;
+                                    note.Duration = 1000000;
+                                }
                             }
                         }
 

--- a/FamiStudio/Source/Utils/ClipboardUtils.cs
+++ b/FamiStudio/Source/Utils/ClipboardUtils.cs
@@ -384,6 +384,19 @@ namespace FamiStudio
                             var instrument = serializer.Project.CreateInstrument(instType, instName);
                             serializer.RemapId(instId, instrument.Id);
                             instrument.Serialize(serializer);
+
+                            // Remove any null sample mappings, otherwise we will crash on cut / copy.
+                            var nullMappings = new List<int>();
+
+                            foreach (var kv in instrument.SamplesMapping)
+                            {
+                                if (kv.Value != null && kv.Value.Sample == null)
+                                    nullMappings.Add(kv.Key);
+                            }
+
+                            foreach (var note in nullMappings)
+                                instrument.UnmapDPCMSample(note);
+
                             instrument.Name = instName;
                         }
                         else

--- a/FamiStudio/Source/Utils/ClipboardUtils.cs
+++ b/FamiStudio/Source/Utils/ClipboardUtils.cs
@@ -385,18 +385,6 @@ namespace FamiStudio
                             serializer.RemapId(instId, instrument.Id);
                             instrument.Serialize(serializer);
 
-                            // Remove any null sample mappings, otherwise we will crash on cut / copy.
-                            var nullMappings = new List<int>();
-
-                            foreach (var kv in instrument.SamplesMapping)
-                            {
-                                if (kv.Value != null && kv.Value.Sample == null)
-                                    nullMappings.Add(kv.Key);
-                            }
-
-                            foreach (var note in nullMappings)
-                                instrument.UnmapDPCMSample(note);
-
                             instrument.Name = instName;
                         }
                         else
@@ -413,6 +401,7 @@ namespace FamiStudio
                 }
             }
 
+            serializer.Project.UnmapUnusedSamples();
             serializer.Project.EnsureAllFoldersExist(FolderType.Instrument);
             serializer.Project.ConditionalSortInstruments();
 


### PR DESCRIPTION
* Fixed incorrect GD3 info being imported to project upon importing a VGM file
* Fixed mobile issue where tapping two different sequencer icons could register as a double-tap
* Fixed video export issue where a DPCM note touching the end of the song retriggered on loop
* Fixed NSF / VGM import issue that resulted in many fine-pitches incorrectly being -1
* Fixed NSF / VGM import issue that caused fine-pitch to always reset to 0 on release
* Fixed minor oscilloscope issues on mobile
* Fixed crash regarding pasting notes without creating missing samples then using cut / copy
* Fixed text import issue that caused tempos of 75 or lower to incorrectly give a tempo error
* Fixed NSF / VGM import issue regarding MMC5 instruments not being compatible with 2A03